### PR TITLE
chore: adopt NuGet Central Package Management

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -11,7 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" PrivateAssets="all" />
-    <PackageReference Include="Meziantou.Analyzer" Version="2.0.173" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.NetAnalyzers" PrivateAssets="all" />
+    <PackageReference Include="Meziantou.Analyzer" PrivateAssets="all" />
   </ItemGroup>
 </Project>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,15 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageVersion Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageVersion Include="xunit" Version="2.9.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.1" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.173" />
+  </ItemGroup>
+</Project>

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ deps-src/
 - Planning: `PLAN.md`
 - CLI UX standards: `docs/CLI_BEST_PRACTICES.md` (derived from https://clig.dev)
 - C# style rules: `.editorconfig`
+- Central package management: `Directory.Packages.props`
 
 ## Git hooks (recommended)
 Install local hooks once per clone:

--- a/src/Nupeek.Cli/Nupeek.Cli.csproj
+++ b/src/Nupeek.Cli/Nupeek.Cli.csproj
@@ -9,6 +9,6 @@
     <ProjectReference Include="..\Nupeek.Core\Nupeek.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta4.22272.1" />
+    <PackageReference Include="System.CommandLine" />
   </ItemGroup>
 </Project>

--- a/tests/Nupeek.Cli.Tests/Nupeek.Cli.Tests.csproj
+++ b/tests/Nupeek.Cli.Tests/Nupeek.Cli.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Nupeek.Core.Tests/Nupeek.Core.Tests.csproj
+++ b/tests/Nupeek.Core.Tests/Nupeek.Core.Tests.csproj
@@ -7,10 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="xunit" Version="2.9.2" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.1" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+    <PackageReference Include="coverlet.collector" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
Follow-up PR to adopt NuGet Central Package Management after PR9 merge.

### Changes
- Add `Directory.Packages.props` with centralized package versions
- Remove inline package `Version` attributes from project files
- Keep analyzer package references in `Directory.Build.props` without local versions
- Document CPM in README

### Validation
- `dotnet restore Nupeek.slnx`
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`

## Notes
This was intended for PR9 but landed after PR9 had already been merged.
