### PR TITLE
🔧 chore(git): enforce conventional commits + icon policy

### DIFF
--- a/.githooks/commit-msg
+++ b/.githooks/commit-msg
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+msg_file="$1"
+msg="$(head -n 1 "$msg_file" | tr -d '\r')"
+
+# Format: <icon> <type>(optional-scope)!: description
+# Example: ✨ feat(cli): add command parser
+pattern='^(✨|🐛|📝|♻️|✅|🔧|🚀|🧪|📦|🔒|🧹|💥) (feat|fix|docs|style|refactor|test|chore|perf|build|ci|revert)(\([a-z0-9._/-]+\))?(!)?: .+'
+
+if [[ ! "$msg" =~ $pattern ]]; then
+  echo "[commit-msg] Invalid commit message format." >&2
+  echo "Expected: <icon> <type>(optional-scope)!: <description>" >&2
+  echo "Example:  ✨ feat(cli): add argument validation" >&2
+  echo "Allowed types: feat, fix, docs, style, refactor, test, chore, perf, build, ci, revert" >&2
+  echo "Allowed icons: ✨ 🐛 📝 ♻️ ✅ 🔧 🚀 🧪 📦 🔒 🧹 💥" >&2
+  exit 1
+fi

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -13,3 +13,4 @@ echo "[pre-commit] Running dotnet test..."
 dotnet test Nupeek.slnx --configuration Release --nologo
 
 echo "[pre-commit] OK"
+echo "[pre-commit] Reminder: commit message format is enforced by .githooks/commit-msg"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,20 @@
+## Summary
+<!-- What changed and why -->
+
+## Validation
+- [ ] `dotnet restore Nupeek.slnx`
+- [ ] `dotnet build Nupeek.slnx -c Release --no-restore`
+- [ ] `dotnet test Nupeek.slnx -c Release --no-build`
+
+## Related
+<!-- Use auto-close keywords, e.g. Closes #123 -->
+
+---
+
+### PR title format (required)
+Use conventional commits + icon in the PR title:
+
+`<icon> <type>(optional-scope): <description>`
+
+Example:
+`✨ feat(cli): add argument validation`

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,20 @@
+name: pr-title
+
+on:
+  pull_request:
+    types: [opened, edited, synchronize, reopened]
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Validate PR title follows icon + conventional commit format
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(✨|🐛|📝|♻️|✅|🔧|🚀|🧪|📦|🔒|🧹|💥) (feat|fix|docs|style|refactor|test|chore|perf|build|ci|revert)(\([a-z0-9._/-]+\))?(!)?: .+'
+          if [[ ! "$PR_TITLE" =~ $pattern ]]; then
+            echo "Invalid PR title: '$PR_TITLE'"
+            echo "Expected: <icon> <type>(optional-scope)!: <description>"
+            exit 1
+          fi

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ Install local hooks once per clone:
 ./scripts/install-hooks.sh
 ```
 
-Enabled pre-commit checks:
-- `dotnet format Nupeek.slnx --verify-no-changes`
-- `dotnet test Nupeek.slnx --configuration Release`
+Enabled hooks:
+- `pre-commit`: `dotnet format Nupeek.slnx --verify-no-changes` + `dotnet test Nupeek.slnx --configuration Release`
+- `commit-msg`: enforces **icon + Conventional Commits** format
+
+Commit/PR title format:
+- `<icon> <type>(optional-scope): <description>`
+- Example: `✨ feat(cli): add argument validation`

--- a/scripts/install-hooks.sh
+++ b/scripts/install-hooks.sh
@@ -6,6 +6,8 @@ repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$repo_root"
 
 git config core.hooksPath .githooks
-chmod +x .githooks/pre-commit
+chmod +x .githooks/pre-commit .githooks/commit-msg
 
-echo "Git hooks installed. pre-commit will run dotnet format and dotnet test."
+echo "Git hooks installed."
+echo "- pre-commit: dotnet format + dotnet test"
+echo "- commit-msg: conventional commits + icon format"


### PR DESCRIPTION
## Summary
Adds repository-level enforcement for icon + Conventional Commits style in both commits and PR titles.

## Changes
- Add `.githooks/commit-msg` to validate commit message format:
  - `<icon> <type>(optional-scope)!: <description>`
- Keep `pre-commit` checks and add reminder that commit message is validated separately
- Update `scripts/install-hooks.sh` to install both pre-commit and commit-msg hooks
- Add `.github/workflows/pr-title.yml` to enforce PR title format in CI
- Add `.github/pull_request_template.md` with required format guidance
- Update README hook/documentation section

## Validation
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`

## Notes
This enforces commits locally (via hooks) and PR titles in GitHub CI.
