### PR TITLE
✨ feat(core): implement NuGet package acquisition cache

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -11,5 +11,7 @@
     <PackageVersion Include="coverlet.collector" Version="6.0.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.NetAnalyzers" Version="9.0.0" />
     <PackageVersion Include="Meziantou.Analyzer" Version="2.0.173" />
+    <PackageVersion Include="NuGet.Protocol" Version="7.0.0" />
+    <PackageVersion Include="NuGet.Packaging" Version="7.0.0" />
   </ItemGroup>
 </Project>

--- a/src/Nupeek.Core/NuGetCacheLayout.cs
+++ b/src/Nupeek.Core/NuGetCacheLayout.cs
@@ -1,0 +1,13 @@
+namespace Nupeek.Core;
+
+public static class NuGetCacheLayout
+{
+    public static string PackageDirectory(string cacheRoot, string packageId, string version)
+        => Path.Combine(cacheRoot, "packages", packageId.ToLowerInvariant(), version);
+
+    public static string NupkgPath(string cacheRoot, string packageId, string version)
+        => Path.Combine(PackageDirectory(cacheRoot, packageId, version), $"{packageId.ToLowerInvariant()}.{version}.nupkg");
+
+    public static string ExtractedPath(string cacheRoot, string packageId, string version)
+        => Path.Combine(PackageDirectory(cacheRoot, packageId, version), "extracted");
+}

--- a/src/Nupeek.Core/NuGetPackageAcquirer.cs
+++ b/src/Nupeek.Core/NuGetPackageAcquirer.cs
@@ -1,0 +1,137 @@
+using NuGet.Common;
+using NuGet.Configuration;
+using NuGet.Packaging.Core;
+using NuGet.Protocol.Core.Types;
+using NuGet.Versioning;
+using System.IO.Compression;
+
+namespace Nupeek.Core;
+
+public sealed class NuGetPackageAcquirer
+{
+    public async Task<NuGetPackageResult> AcquireAsync(NuGetPackageRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.PackageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.CacheRoot);
+
+        var logger = NullLogger.Instance;
+        var repositories = GetRepositories();
+        var packageId = request.PackageId.Trim();
+        var version = await ResolveVersionAsync(repositories, packageId, request.Version, logger, cancellationToken).ConfigureAwait(false);
+
+        var packageDir = NuGetCacheLayout.PackageDirectory(request.CacheRoot, packageId, version);
+        var nupkgPath = NuGetCacheLayout.NupkgPath(request.CacheRoot, packageId, version);
+        var extractedPath = NuGetCacheLayout.ExtractedPath(request.CacheRoot, packageId, version);
+
+        Directory.CreateDirectory(packageDir);
+
+        if (!File.Exists(nupkgPath))
+        {
+            await DownloadPackageAsync(repositories, packageId, version, nupkgPath, logger, cancellationToken).ConfigureAwait(false);
+        }
+
+        if (!Directory.Exists(extractedPath) || Directory.GetFileSystemEntries(extractedPath).Length == 0)
+        {
+            if (Directory.Exists(extractedPath))
+            {
+                Directory.Delete(extractedPath, recursive: true);
+            }
+
+            ZipFile.ExtractToDirectory(nupkgPath, extractedPath);
+        }
+
+        return new NuGetPackageResult(packageId, version, packageDir, nupkgPath, extractedPath);
+    }
+
+    private static IReadOnlyList<SourceRepository> GetRepositories()
+    {
+        var providers = Repository.Provider.GetCoreV3();
+        var packageSources = Settings.LoadDefaultSettings(root: null)
+            .GetSection("packageSources")?
+            .Items?
+            .OfType<SourceItem>()
+            .Select(x => new PackageSource(x.GetValueAsPath()))
+            .ToList();
+
+        packageSources ??= [];
+        if (!packageSources.Any(static x => x.Source.Contains("nuget.org", StringComparison.OrdinalIgnoreCase)))
+        {
+            packageSources.Add(new PackageSource("https://api.nuget.org/v3/index.json"));
+        }
+
+        return packageSources.Select(source => new SourceRepository(source, providers)).ToList();
+    }
+
+    private static async Task<string> ResolveVersionAsync(
+        IReadOnlyList<SourceRepository> repositories,
+        string packageId,
+        string? requestedVersion,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedVersion))
+        {
+            return requestedVersion.Trim();
+        }
+
+        var versions = new List<NuGetVersion>();
+
+        foreach (var repository in repositories)
+        {
+            var metadata = await repository.GetResourceAsync<PackageMetadataResource>(cancellationToken).ConfigureAwait(false);
+            using var cacheContext = new SourceCacheContext();
+            var found = await metadata.GetMetadataAsync(packageId, includePrerelease: false, includeUnlisted: false, cacheContext, logger, cancellationToken).ConfigureAwait(false);
+            versions.AddRange(found.Select(m => m.Identity.Version));
+        }
+
+        var latest = versions
+            .Distinct()
+            .OrderByDescending(static x => x)
+            .FirstOrDefault();
+
+        if (latest is null)
+        {
+            throw new InvalidOperationException($"Package '{packageId}' was not found.");
+        }
+
+        return latest.ToNormalizedString();
+    }
+
+    private static async Task DownloadPackageAsync(
+        IReadOnlyList<SourceRepository> repositories,
+        string packageId,
+        string version,
+        string destinationPath,
+        ILogger logger,
+        CancellationToken cancellationToken)
+    {
+        var identity = new PackageIdentity(packageId, NuGetVersion.Parse(version));
+
+        foreach (var repository in repositories)
+        {
+            var resource = await repository.GetResourceAsync<FindPackageByIdResource>(cancellationToken).ConfigureAwait(false);
+            using var cacheContext = new SourceCacheContext();
+            using var memory = new MemoryStream();
+
+            var found = await resource.CopyNupkgToStreamAsync(
+                identity.Id,
+                identity.Version,
+                memory,
+                cacheContext,
+                logger,
+                cancellationToken).ConfigureAwait(false);
+
+            if (!found)
+            {
+                continue;
+            }
+
+            memory.Position = 0;
+            using var file = File.Create(destinationPath);
+            await memory.CopyToAsync(file, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        throw new InvalidOperationException($"Unable to download package '{packageId}' version '{version}'.");
+    }
+}

--- a/src/Nupeek.Core/NuGetPackageRequest.cs
+++ b/src/Nupeek.Core/NuGetPackageRequest.cs
@@ -1,0 +1,6 @@
+namespace Nupeek.Core;
+
+public sealed record NuGetPackageRequest(
+    string PackageId,
+    string? Version,
+    string CacheRoot);

--- a/src/Nupeek.Core/NuGetPackageResult.cs
+++ b/src/Nupeek.Core/NuGetPackageResult.cs
@@ -1,0 +1,8 @@
+namespace Nupeek.Core;
+
+public sealed record NuGetPackageResult(
+    string PackageId,
+    string Version,
+    string PackageDirectory,
+    string NupkgPath,
+    string ExtractedPath);

--- a/src/Nupeek.Core/Nupeek.Core.csproj
+++ b/src/Nupeek.Core/Nupeek.Core.csproj
@@ -4,4 +4,8 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="NuGet.Protocol" />
+    <PackageReference Include="NuGet.Packaging" />
+  </ItemGroup>
 </Project>

--- a/tests/Nupeek.Core.Tests/NuGetCacheLayoutTests.cs
+++ b/tests/Nupeek.Core.Tests/NuGetCacheLayoutTests.cs
@@ -1,0 +1,11 @@
+namespace Nupeek.Core.Tests;
+
+public class NuGetCacheLayoutTests
+{
+    [Fact]
+    public void PackageDirectory_UsesDeterministicLayout()
+    {
+        var path = NuGetCacheLayout.PackageDirectory("deps-src/.cache", "Newtonsoft.Json", "13.0.3");
+        Assert.EndsWith(Path.Combine("deps-src", ".cache", "packages", "newtonsoft.json", "13.0.3"), path, StringComparison.Ordinal);
+    }
+}

--- a/tests/Nupeek.Core.Tests/NuGetPackageAcquirerTests.cs
+++ b/tests/Nupeek.Core.Tests/NuGetPackageAcquirerTests.cs
@@ -1,0 +1,27 @@
+namespace Nupeek.Core.Tests;
+
+public class NuGetPackageAcquirerTests
+{
+    [Fact]
+    public async Task AcquireAsync_DownloadsAndExtractsPackage()
+    {
+        var cacheRoot = Path.Combine(Path.GetTempPath(), "nupeek-tests", Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var acquirer = new NuGetPackageAcquirer();
+            var result = await acquirer.AcquireAsync(new NuGetPackageRequest("Humanizer.Core", "2.14.1", cacheRoot));
+
+            Assert.True(File.Exists(result.NupkgPath));
+            Assert.True(Directory.Exists(result.ExtractedPath));
+            Assert.Equal("2.14.1", result.Version);
+        }
+        finally
+        {
+            if (Directory.Exists(cacheRoot))
+            {
+                Directory.Delete(cacheRoot, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements NuGet package acquisition + cache foundation in core.

## Changes
- Added `NuGetPackageAcquirer` to:
  - resolve package versions (latest stable when version not provided)
  - download `.nupkg` from NuGet
  - extract package into deterministic cache paths
- Added cache layout helper `NuGetCacheLayout`
- Added request/result models for acquisition flow
- Added tests for cache layout and acquisition path
- Added NuGet dependencies to centralized package management

## Validation
- `dotnet restore Nupeek.slnx`
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`
- `dotnet format Nupeek.slnx --verify-no-changes`

## Related
Closes #12
