### PR TITLE
✨ feat(core): resolve lib TFM and discover assembly by type

### DIFF
--- a/src/Nupeek.Core/PackageContentRequest.cs
+++ b/src/Nupeek.Core/PackageContentRequest.cs
@@ -1,0 +1,6 @@
+namespace Nupeek.Core;
+
+public sealed record PackageContentRequest(
+    string ExtractedPath,
+    string FullTypeName,
+    string? Tfm);

--- a/src/Nupeek.Core/PackageContentResult.cs
+++ b/src/Nupeek.Core/PackageContentResult.cs
@@ -1,0 +1,7 @@
+namespace Nupeek.Core;
+
+public sealed record PackageContentResult(
+    string SelectedTfm,
+    string LibDirectory,
+    string AssemblyPath,
+    string FullTypeName);

--- a/src/Nupeek.Core/PackageTypeLocator.cs
+++ b/src/Nupeek.Core/PackageTypeLocator.cs
@@ -1,0 +1,82 @@
+using System.Reflection.Metadata;
+using System.Reflection.PortableExecutable;
+
+namespace Nupeek.Core;
+
+public sealed class PackageTypeLocator
+{
+    public PackageContentResult Locate(PackageContentRequest request)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.ExtractedPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.FullTypeName);
+
+        var libRoot = Path.Combine(request.ExtractedPath, "lib");
+        if (!Directory.Exists(libRoot))
+        {
+            throw new InvalidOperationException($"Package does not contain a lib folder: {libRoot}");
+        }
+
+        var tfmDirectories = Directory.GetDirectories(libRoot)
+            .Select(Path.GetFileName)
+            .Where(static x => !string.IsNullOrWhiteSpace(x))
+            .Cast<string>()
+            .ToList();
+
+        if (tfmDirectories.Count == 0)
+        {
+            throw new InvalidOperationException($"No target frameworks found under: {libRoot}");
+        }
+
+        var selectedTfm = string.IsNullOrWhiteSpace(request.Tfm)
+            ? TfmSelector.SelectBest(tfmDirectories)
+            : request.Tfm.Trim();
+
+        var selectedLibDir = Path.Combine(libRoot, selectedTfm);
+        if (!Directory.Exists(selectedLibDir))
+        {
+            throw new InvalidOperationException($"Requested TFM '{selectedTfm}' not found in package.");
+        }
+
+        var assemblyPath = FindAssemblyContainingType(selectedLibDir, request.FullTypeName)
+            ?? throw new InvalidOperationException($"Type '{request.FullTypeName}' was not found in '{selectedLibDir}'.");
+
+        return new PackageContentResult(selectedTfm, selectedLibDir, assemblyPath, request.FullTypeName);
+    }
+
+    private static string? FindAssemblyContainingType(string libDir, string fullTypeName)
+    {
+        foreach (var dll in Directory.GetFiles(libDir, "*.dll"))
+        {
+            try
+            {
+                using var stream = File.OpenRead(dll);
+                using var peReader = new PEReader(stream);
+
+                if (!peReader.HasMetadata)
+                {
+                    continue;
+                }
+
+                var md = peReader.GetMetadataReader();
+                foreach (var handle in md.TypeDefinitions)
+                {
+                    var typeDef = md.GetTypeDefinition(handle);
+                    var ns = md.GetString(typeDef.Namespace);
+                    var name = md.GetString(typeDef.Name);
+                    var candidate = string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+
+                    if (string.Equals(candidate, fullTypeName, StringComparison.Ordinal))
+                    {
+                        return dll;
+                    }
+                }
+            }
+            catch
+            {
+                // Skip non-managed or unreadable binaries.
+            }
+        }
+
+        return null;
+    }
+}

--- a/tests/Nupeek.Core.Tests/PackageTypeLocatorTests.cs
+++ b/tests/Nupeek.Core.Tests/PackageTypeLocatorTests.cs
@@ -1,0 +1,55 @@
+namespace Nupeek.Core.Tests;
+
+public class PackageTypeLocatorTests
+{
+    [Fact]
+    public async Task Locate_FindsAssemblyForKnownType()
+    {
+        var cacheRoot = Path.Combine(Path.GetTempPath(), "nupeek-tests", Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var acquirer = new NuGetPackageAcquirer();
+            var package = await acquirer.AcquireAsync(new NuGetPackageRequest("Humanizer.Core", "2.14.1", cacheRoot));
+
+            var locator = new PackageTypeLocator();
+            var result = locator.Locate(new PackageContentRequest(
+                package.ExtractedPath,
+                "Humanizer.StringHumanizeExtensions",
+                "netstandard2.0"));
+
+            Assert.Equal("netstandard2.0", result.SelectedTfm);
+            Assert.True(File.Exists(result.AssemblyPath));
+        }
+        finally
+        {
+            if (Directory.Exists(cacheRoot))
+            {
+                Directory.Delete(cacheRoot, recursive: true);
+            }
+        }
+    }
+
+    [Fact]
+    public async Task Locate_ThrowsForMissingTfm()
+    {
+        var cacheRoot = Path.Combine(Path.GetTempPath(), "nupeek-tests", Guid.NewGuid().ToString("N"));
+
+        try
+        {
+            var acquirer = new NuGetPackageAcquirer();
+            var package = await acquirer.AcquireAsync(new NuGetPackageRequest("Humanizer.Core", "2.14.1", cacheRoot));
+            var locator = new PackageTypeLocator();
+
+            Assert.Throws<InvalidOperationException>(() =>
+                locator.Locate(new PackageContentRequest(package.ExtractedPath, "Humanizer.StringHumanizeExtensions", "net9.0")));
+        }
+        finally
+        {
+            if (Directory.Exists(cacheRoot))
+            {
+                Directory.Delete(cacheRoot, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements package content resolution for type discovery.

## Changes
- Added `PackageTypeLocator` to:
  - resolve selected `lib/<tfm>` directory
  - support explicit TFM selection
  - auto-select best TFM when omitted
  - scan managed DLL metadata and find assembly containing full type name
- Added `PackageContentRequest` / `PackageContentResult` models
- Added tests for known type discovery and missing TFM behavior

## Validation
- `dotnet restore Nupeek.slnx`
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`
- `dotnet format Nupeek.slnx --verify-no-changes`

## Related
Closes #14
