### PR TITLE
✨ feat(cli): implement decompile pipeline and output catalogs

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -13,5 +13,6 @@
     <PackageVersion Include="Meziantou.Analyzer" Version="2.0.173" />
     <PackageVersion Include="NuGet.Protocol" Version="7.0.0" />
     <PackageVersion Include="NuGet.Packaging" Version="7.0.0" />
+    <PackageVersion Include="ICSharpCode.Decompiler" Version="9.1.0.7988" />
   </ItemGroup>
 </Project>

--- a/src/Nupeek.Core/Nupeek.Core.csproj
+++ b/src/Nupeek.Core/Nupeek.Core.csproj
@@ -7,5 +7,6 @@
   <ItemGroup>
     <PackageReference Include="NuGet.Protocol" />
     <PackageReference Include="NuGet.Packaging" />
+    <PackageReference Include="ICSharpCode.Decompiler" />
   </ItemGroup>
 </Project>

--- a/src/Nupeek.Core/OutputCatalogWriter.cs
+++ b/src/Nupeek.Core/OutputCatalogWriter.cs
@@ -1,0 +1,65 @@
+using Nupeek.Core.Models;
+using System.Text.Json;
+
+namespace Nupeek.Core;
+
+public sealed class OutputCatalogWriter
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        WriteIndented = true,
+    };
+
+    public string WriteIndex(string outputRoot, string typeName, string outputPath)
+    {
+        var indexPath = Path.Combine(outputRoot, "index.json");
+        Directory.CreateDirectory(outputRoot);
+
+        var index = ReadJson<TypeIndex>(indexPath) ?? new TypeIndex();
+        index[typeName] = outputPath;
+
+        File.WriteAllText(indexPath, JsonSerializer.Serialize(index, JsonOptions));
+        return indexPath;
+    }
+
+    public string WriteManifest(string outputRoot, ManifestEntry entry)
+    {
+        var manifestPath = Path.Combine(outputRoot, "manifest.json");
+        Directory.CreateDirectory(outputRoot);
+
+        var manifest = ReadJson<List<ManifestEntry>>(manifestPath) ?? [];
+        var existingIndex = manifest.FindIndex(x =>
+            string.Equals(x.PackageId, entry.PackageId, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(x.Version, entry.Version, StringComparison.Ordinal)
+            && string.Equals(x.Tfm, entry.Tfm, StringComparison.OrdinalIgnoreCase)
+            && string.Equals(x.TypeName, entry.TypeName, StringComparison.Ordinal));
+
+        if (existingIndex >= 0)
+        {
+            manifest[existingIndex] = entry;
+        }
+        else
+        {
+            manifest.Add(entry);
+        }
+
+        File.WriteAllText(manifestPath, JsonSerializer.Serialize(manifest, JsonOptions));
+        return manifestPath;
+    }
+
+    private static T? ReadJson<T>(string path)
+    {
+        if (!File.Exists(path))
+        {
+            return default;
+        }
+
+        var json = File.ReadAllText(path);
+        if (string.IsNullOrWhiteSpace(json))
+        {
+            return default;
+        }
+
+        return JsonSerializer.Deserialize<T>(json, JsonOptions);
+    }
+}

--- a/src/Nupeek.Core/TypeDecompilePipeline.cs
+++ b/src/Nupeek.Core/TypeDecompilePipeline.cs
@@ -1,0 +1,73 @@
+using Nupeek.Core.Models;
+
+namespace Nupeek.Core;
+
+public sealed class TypeDecompilePipeline
+{
+    private readonly NuGetPackageAcquirer _acquirer;
+    private readonly PackageTypeLocator _locator;
+    private readonly TypeDecompiler _decompiler;
+    private readonly OutputCatalogWriter _catalogWriter;
+
+    public TypeDecompilePipeline()
+        : this(new NuGetPackageAcquirer(), new PackageTypeLocator(), new TypeDecompiler(), new OutputCatalogWriter())
+    {
+    }
+
+    public TypeDecompilePipeline(
+        NuGetPackageAcquirer acquirer,
+        PackageTypeLocator locator,
+        TypeDecompiler decompiler,
+        OutputCatalogWriter catalogWriter)
+    {
+        _acquirer = acquirer;
+        _locator = locator;
+        _decompiler = decompiler;
+        _catalogWriter = catalogWriter;
+    }
+
+    public async Task<TypeDecompileResult> RunAsync(TypeDecompileRequest request, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.PackageId);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.TypeName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(request.OutputRoot);
+
+        var cacheRoot = Path.Combine(request.OutputRoot, ".cache");
+
+        var package = await _acquirer.AcquireAsync(new NuGetPackageRequest(request.PackageId, request.Version, cacheRoot), cancellationToken).ConfigureAwait(false);
+
+        var content = _locator.Locate(new PackageContentRequest(
+            package.ExtractedPath,
+            request.TypeName,
+            request.Tfm));
+
+        var outputPath = OutputPathBuilder.BuildTypeOutputPath(
+            request.OutputRoot,
+            package.PackageId,
+            package.Version,
+            content.SelectedTfm,
+            request.TypeName);
+
+        _decompiler.DecompileType(content.AssemblyPath, request.TypeName, outputPath);
+
+        var indexPath = _catalogWriter.WriteIndex(request.OutputRoot, request.TypeName, outputPath);
+        var manifestPath = _catalogWriter.WriteManifest(request.OutputRoot, new ManifestEntry(
+            package.PackageId,
+            package.Version,
+            content.SelectedTfm,
+            request.TypeName,
+            content.AssemblyPath,
+            outputPath,
+            DateTimeOffset.UtcNow));
+
+        return new TypeDecompileResult(
+            package.PackageId,
+            package.Version,
+            content.SelectedTfm,
+            request.TypeName,
+            content.AssemblyPath,
+            outputPath,
+            indexPath,
+            manifestPath);
+    }
+}

--- a/src/Nupeek.Core/TypeDecompileRequest.cs
+++ b/src/Nupeek.Core/TypeDecompileRequest.cs
@@ -1,0 +1,8 @@
+namespace Nupeek.Core;
+
+public sealed record TypeDecompileRequest(
+    string PackageId,
+    string? Version,
+    string? Tfm,
+    string TypeName,
+    string OutputRoot);

--- a/src/Nupeek.Core/TypeDecompileResult.cs
+++ b/src/Nupeek.Core/TypeDecompileResult.cs
@@ -1,0 +1,11 @@
+namespace Nupeek.Core;
+
+public sealed record TypeDecompileResult(
+    string PackageId,
+    string Version,
+    string Tfm,
+    string TypeName,
+    string AssemblyPath,
+    string OutputPath,
+    string IndexPath,
+    string ManifestPath);

--- a/src/Nupeek.Core/TypeDecompiler.cs
+++ b/src/Nupeek.Core/TypeDecompiler.cs
@@ -1,0 +1,31 @@
+using ICSharpCode.Decompiler;
+using ICSharpCode.Decompiler.CSharp;
+using ICSharpCode.Decompiler.TypeSystem;
+
+namespace Nupeek.Core;
+
+public sealed class TypeDecompiler
+{
+    public void DecompileType(string assemblyPath, string fullTypeName, string outputPath)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assemblyPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fullTypeName);
+        ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
+
+        var settings = new DecompilerSettings
+        {
+            ThrowOnAssemblyResolveErrors = false,
+            NullableReferenceTypes = true,
+            UsingDeclarations = true,
+        };
+
+        var decompiler = new CSharpDecompiler(assemblyPath, settings);
+        var syntax = decompiler.DecompileType(new FullTypeName(fullTypeName));
+
+        var directory = Path.GetDirectoryName(outputPath)
+            ?? throw new InvalidOperationException("Output path directory is missing.");
+
+        Directory.CreateDirectory(directory);
+        File.WriteAllText(outputPath, syntax.ToString());
+    }
+}

--- a/tests/Nupeek.Core.Tests/TypeDecompilePipelineTests.cs
+++ b/tests/Nupeek.Core.Tests/TypeDecompilePipelineTests.cs
@@ -1,0 +1,39 @@
+namespace Nupeek.Core.Tests;
+
+public class TypeDecompilePipelineTests
+{
+    [Fact]
+    public async Task RunAsync_WritesDecompiledTypeAndCatalogFiles()
+    {
+        var outputRoot = Path.Combine(Path.GetTempPath(), "nupeek-tests", Guid.NewGuid().ToString("N"), "deps-src");
+
+        try
+        {
+            var pipeline = new TypeDecompilePipeline();
+            var result = await pipeline.RunAsync(new TypeDecompileRequest(
+                "Humanizer.Core",
+                "2.14.1",
+                "netstandard2.0",
+                "Humanizer.StringHumanizeExtensions",
+                outputRoot));
+
+            Assert.True(File.Exists(result.OutputPath));
+            Assert.True(File.Exists(result.IndexPath));
+            Assert.True(File.Exists(result.ManifestPath));
+
+            var indexJson = await File.ReadAllTextAsync(result.IndexPath);
+            Assert.Contains("Humanizer.StringHumanizeExtensions", indexJson, StringComparison.Ordinal);
+
+            var manifestJson = await File.ReadAllTextAsync(result.ManifestPath);
+            Assert.Contains("Humanizer.Core", manifestJson, StringComparison.Ordinal);
+        }
+        finally
+        {
+            var root = Directory.GetParent(outputRoot)?.Parent?.FullName ?? outputRoot;
+            if (Directory.Exists(root))
+            {
+                Directory.Delete(root, recursive: true);
+            }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
Implements end-to-end type decompilation pipeline and output artifacts.

## Changes
- Added `TypeDecompilePipeline` orchestrating:
  - package acquire
  - TFM/lib/type assembly discovery
  - decompile target type
  - write output index + manifest
- Added `TypeDecompiler` using ILSpy engine
- Added `OutputCatalogWriter` to upsert `index.json` and `manifest.json`
- Added request/result models for decompile pipeline
- Wired CLI execution path when `--dry-run false`
- Added integration test verifying output file, index, and manifest creation

## Validation
- `dotnet restore Nupeek.slnx`
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`
- `dotnet format Nupeek.slnx --verify-no-changes`

## Related
Closes #16
