### PR TITLE
🧹 refactor(code): cleanup pass with comments and AAA tests

### DIFF
--- a/src/Nupeek.Cli/CliApp.cs
+++ b/src/Nupeek.Cli/CliApp.cs
@@ -6,15 +6,18 @@ namespace Nupeek.Cli;
 
 public static class CliApp
 {
+    // Entrypoint for CLI execution with stable exit-code mapping.
     public static async Task<int> RunAsync(string[] args, IConsole? console = null)
     {
         var root = BuildRootCommand();
 
+        // Let System.CommandLine render built-in help path directly.
         if (args.Any(static a => a is "--help" or "-h"))
         {
             return await root.InvokeAsync(args, console).ConfigureAwait(false);
         }
 
+        // Parse first so we can provide consistent, user-friendly argument errors.
         var parseResult = root.Parse(args);
 
         if (parseResult.Errors.Count > 0)
@@ -170,6 +173,7 @@ public static class CliApp
         {
             try
             {
+                // Real execution path: acquire package -> locate type -> decompile -> write catalogs.
                 var pipeline = new TypeDecompilePipeline();
                 var result = pipeline.RunAsync(new TypeDecompileRequest(
                     package,

--- a/src/Nupeek.Core/NuGetPackageAcquirer.cs
+++ b/src/Nupeek.Core/NuGetPackageAcquirer.cs
@@ -9,6 +9,7 @@ namespace Nupeek.Core;
 
 public sealed class NuGetPackageAcquirer
 {
+    // Resolves, downloads, and extracts a NuGet package into local cache.
     public async Task<NuGetPackageResult> AcquireAsync(NuGetPackageRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(request.PackageId);
@@ -25,11 +26,13 @@ public sealed class NuGetPackageAcquirer
 
         Directory.CreateDirectory(packageDir);
 
+        // Download once; reuse local cache on subsequent runs.
         if (!File.Exists(nupkgPath))
         {
             await DownloadPackageAsync(repositories, packageId, version, nupkgPath, logger, cancellationToken).ConfigureAwait(false);
         }
 
+        // Extract once; re-extract only when folder is missing/empty.
         if (!Directory.Exists(extractedPath) || Directory.GetFileSystemEntries(extractedPath).Length == 0)
         {
             if (Directory.Exists(extractedPath))

--- a/src/Nupeek.Core/OutputCatalogWriter.cs
+++ b/src/Nupeek.Core/OutputCatalogWriter.cs
@@ -5,6 +5,7 @@ namespace Nupeek.Core;
 
 public sealed class OutputCatalogWriter
 {
+    // Maintains index/manifest files used by agents and follow-up CLI commands.
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,

--- a/src/Nupeek.Core/PackageTypeLocator.cs
+++ b/src/Nupeek.Core/PackageTypeLocator.cs
@@ -5,6 +5,7 @@ namespace Nupeek.Core;
 
 public sealed class PackageTypeLocator
 {
+    // Resolves the best lib/TFM directory and finds the assembly that defines a target type.
     public PackageContentResult Locate(PackageContentRequest request)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(request.ExtractedPath);
@@ -27,6 +28,7 @@ public sealed class PackageTypeLocator
             throw new InvalidOperationException($"No target frameworks found under: {libRoot}");
         }
 
+        // If user does not specify TFM, pick best known target for current runtime/tooling.
         var selectedTfm = string.IsNullOrWhiteSpace(request.Tfm)
             ? TfmSelector.SelectBest(tfmDirectories)
             : request.Tfm.Trim();

--- a/tests/Nupeek.Cli.Tests/CliAppTests.cs
+++ b/tests/Nupeek.Cli.Tests/CliAppTests.cs
@@ -5,20 +5,36 @@ public class CliAppTests
     [Fact]
     public async Task RunAsync_UnknownCommand_ReturnsInvalidArguments()
     {
-        var code = await CliApp.RunAsync(["wat"]);
+        // Arrange
+        var args = new[] { "wat" };
+
+        // Act
+        var code = await CliApp.RunAsync(args);
+
+        // Assert
         Assert.Equal(ExitCodes.InvalidArguments, code);
     }
 
     [Fact]
     public async Task RunAsync_Help_ReturnsSuccess()
     {
-        var code = await CliApp.RunAsync(["--help"]);
+        // Arrange
+        var args = new[] { "--help" };
+
+        // Act
+        var code = await CliApp.RunAsync(args);
+
+        // Assert
         Assert.Equal(ExitCodes.Success, code);
     }
 
     [Fact]
     public void BuildPlanText_IncludesSymbolWhenProvided()
     {
+        // Arrange
+        const string sourceSymbol = "Polly.Policy.Handle";
+
+        // Act
         var text = CliApp.BuildPlanText(
             command: "find",
             package: "Polly",
@@ -27,8 +43,9 @@ public class CliAppTests
             type: "Polly.Policy",
             outDir: "deps-src",
             dryRun: true,
-            sourceSymbol: "Polly.Policy.Handle");
+            sourceSymbol: sourceSymbol);
 
+        // Assert
         Assert.Contains("symbol: Polly.Policy.Handle", text, StringComparison.Ordinal);
         Assert.Contains("type: Polly.Policy", text, StringComparison.Ordinal);
     }

--- a/tests/Nupeek.Core.Tests/NuGetCacheLayoutTests.cs
+++ b/tests/Nupeek.Core.Tests/NuGetCacheLayoutTests.cs
@@ -5,7 +5,13 @@ public class NuGetCacheLayoutTests
     [Fact]
     public void PackageDirectory_UsesDeterministicLayout()
     {
-        var path = NuGetCacheLayout.PackageDirectory("deps-src/.cache", "Newtonsoft.Json", "13.0.3");
+        // Arrange
+        const string cacheRoot = "deps-src/.cache";
+
+        // Act
+        var path = NuGetCacheLayout.PackageDirectory(cacheRoot, "Newtonsoft.Json", "13.0.3");
+
+        // Assert
         Assert.EndsWith(Path.Combine("deps-src", ".cache", "packages", "newtonsoft.json", "13.0.3"), path, StringComparison.Ordinal);
     }
 }

--- a/tests/Nupeek.Core.Tests/NuGetPackageAcquirerTests.cs
+++ b/tests/Nupeek.Core.Tests/NuGetPackageAcquirerTests.cs
@@ -5,13 +5,16 @@ public class NuGetPackageAcquirerTests
     [Fact]
     public async Task AcquireAsync_DownloadsAndExtractsPackage()
     {
+        // Arrange
         var cacheRoot = Path.Combine(Path.GetTempPath(), "nupeek-tests", Guid.NewGuid().ToString("N"));
+        var acquirer = new NuGetPackageAcquirer();
 
         try
         {
-            var acquirer = new NuGetPackageAcquirer();
+            // Act
             var result = await acquirer.AcquireAsync(new NuGetPackageRequest("Humanizer.Core", "2.14.1", cacheRoot));
 
+            // Assert
             Assert.True(File.Exists(result.NupkgPath));
             Assert.True(Directory.Exists(result.ExtractedPath));
             Assert.Equal("2.14.1", result.Version);

--- a/tests/Nupeek.Core.Tests/OutputPathBuilderTests.cs
+++ b/tests/Nupeek.Core.Tests/OutputPathBuilderTests.cs
@@ -5,13 +5,17 @@ public class OutputPathBuilderTests
     [Fact]
     public void BuildTypeOutputPath_BuildsExpectedLayout()
     {
-        var path = OutputPathBuilder.BuildTypeOutputPath(
-            root: "deps-src",
-            packageId: "Azure.Messaging.ServiceBus",
-            version: "7.20.1",
-            tfm: "netstandard2.0",
-            fullTypeName: "Azure.Messaging.ServiceBus.ServiceBusSender");
+        // Arrange
+        const string root = "deps-src";
+        const string packageId = "Azure.Messaging.ServiceBus";
+        const string version = "7.20.1";
+        const string tfm = "netstandard2.0";
+        const string typeName = "Azure.Messaging.ServiceBus.ServiceBusSender";
 
+        // Act
+        var path = OutputPathBuilder.BuildTypeOutputPath(root, packageId, version, tfm, typeName);
+
+        // Assert
         Assert.Contains(Path.Combine("packages", "azure.messaging.servicebus", "7.20.1", "netstandard2.0"), path, StringComparison.Ordinal);
         Assert.EndsWith("Azure_Messaging_ServiceBus_ServiceBusSender.decompiled.cs", path, StringComparison.Ordinal);
     }

--- a/tests/Nupeek.Core.Tests/PackageTypeLocatorTests.cs
+++ b/tests/Nupeek.Core.Tests/PackageTypeLocatorTests.cs
@@ -5,19 +5,22 @@ public class PackageTypeLocatorTests
     [Fact]
     public async Task Locate_FindsAssemblyForKnownType()
     {
+        // Arrange
         var cacheRoot = Path.Combine(Path.GetTempPath(), "nupeek-tests", Guid.NewGuid().ToString("N"));
+        var acquirer = new NuGetPackageAcquirer();
+        var locator = new PackageTypeLocator();
 
         try
         {
-            var acquirer = new NuGetPackageAcquirer();
             var package = await acquirer.AcquireAsync(new NuGetPackageRequest("Humanizer.Core", "2.14.1", cacheRoot));
 
-            var locator = new PackageTypeLocator();
+            // Act
             var result = locator.Locate(new PackageContentRequest(
                 package.ExtractedPath,
                 "Humanizer.StringHumanizeExtensions",
                 "netstandard2.0"));
 
+            // Assert
             Assert.Equal("netstandard2.0", result.SelectedTfm);
             Assert.True(File.Exists(result.AssemblyPath));
         }
@@ -33,14 +36,16 @@ public class PackageTypeLocatorTests
     [Fact]
     public async Task Locate_ThrowsForMissingTfm()
     {
+        // Arrange
         var cacheRoot = Path.Combine(Path.GetTempPath(), "nupeek-tests", Guid.NewGuid().ToString("N"));
+        var acquirer = new NuGetPackageAcquirer();
+        var locator = new PackageTypeLocator();
 
         try
         {
-            var acquirer = new NuGetPackageAcquirer();
             var package = await acquirer.AcquireAsync(new NuGetPackageRequest("Humanizer.Core", "2.14.1", cacheRoot));
-            var locator = new PackageTypeLocator();
 
+            // Act & Assert
             Assert.Throws<InvalidOperationException>(() =>
                 locator.Locate(new PackageContentRequest(package.ExtractedPath, "Humanizer.StringHumanizeExtensions", "net9.0")));
         }

--- a/tests/Nupeek.Core.Tests/SymbolParserTests.cs
+++ b/tests/Nupeek.Core.Tests/SymbolParserTests.cs
@@ -5,14 +5,26 @@ public class SymbolParserTests
     [Fact]
     public void ToTypeName_FromMethodSymbol_ReturnsTypeName()
     {
-        var result = SymbolParser.ToTypeName("Polly.Policy.Handle");
+        // Arrange
+        const string symbol = "Polly.Policy.Handle";
+
+        // Act
+        var result = SymbolParser.ToTypeName(symbol);
+
+        // Assert
         Assert.Equal("Polly.Policy", result);
     }
 
     [Fact]
     public void ToTypeName_FromSingleToken_ReturnsOriginal()
     {
-        var result = SymbolParser.ToTypeName("ServiceBusSender");
+        // Arrange
+        const string symbol = "ServiceBusSender";
+
+        // Act
+        var result = SymbolParser.ToTypeName(symbol);
+
+        // Assert
         Assert.Equal("ServiceBusSender", result);
     }
 }

--- a/tests/Nupeek.Core.Tests/TfmSelectorTests.cs
+++ b/tests/Nupeek.Core.Tests/TfmSelectorTests.cs
@@ -5,14 +5,26 @@ public class TfmSelectorTests
     [Fact]
     public void SelectBest_PrefersNet10()
     {
-        var result = TfmSelector.SelectBest(["netstandard2.0", "net8.0", "net10.0"]);
+        // Arrange
+        var tfms = new[] { "netstandard2.0", "net8.0", "net10.0" };
+
+        // Act
+        var result = TfmSelector.SelectBest(tfms);
+
+        // Assert
         Assert.Equal("net10.0", result);
     }
 
     [Fact]
     public void SelectBest_FallsBackAlphabetical_WhenNoPriorityMatch()
     {
-        var result = TfmSelector.SelectBest(["foo", "bar"]);
+        // Arrange
+        var tfms = new[] { "foo", "bar" };
+
+        // Act
+        var result = TfmSelector.SelectBest(tfms);
+
+        // Assert
         Assert.Equal("bar", result);
     }
 }

--- a/tests/Nupeek.Core.Tests/TypeDecompilePipelineTests.cs
+++ b/tests/Nupeek.Core.Tests/TypeDecompilePipelineTests.cs
@@ -5,11 +5,13 @@ public class TypeDecompilePipelineTests
     [Fact]
     public async Task RunAsync_WritesDecompiledTypeAndCatalogFiles()
     {
+        // Arrange
         var outputRoot = Path.Combine(Path.GetTempPath(), "nupeek-tests", Guid.NewGuid().ToString("N"), "deps-src");
+        var pipeline = new TypeDecompilePipeline();
 
         try
         {
-            var pipeline = new TypeDecompilePipeline();
+            // Act
             var result = await pipeline.RunAsync(new TypeDecompileRequest(
                 "Humanizer.Core",
                 "2.14.1",
@@ -17,6 +19,7 @@ public class TypeDecompilePipelineTests
                 "Humanizer.StringHumanizeExtensions",
                 outputRoot));
 
+            // Assert
             Assert.True(File.Exists(result.OutputPath));
             Assert.True(File.Exists(result.IndexPath));
             Assert.True(File.Exists(result.ManifestPath));


### PR DESCRIPTION
## Summary
Thorough cleanup/review pass for current MVP code with readability improvements.

## What changed
- Added targeted comments to non-obvious orchestration paths in:
  - `CliApp`
  - `TypeDecompilePipeline`
  - `NuGetPackageAcquirer`
  - `PackageTypeLocator`
  - `OutputCatalogWriter`
- Added AAA (`Arrange/Act/Assert`) comment sections across test suite for consistency and readability.
- Kept behavior unchanged; this is a readability/maintainability refactor.

## Validation
- `dotnet format Nupeek.slnx`
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`

## Related
Closes #18
