### PR TITLE
📝 docs(code): add detailed comments across source classes and methods

### DIFF
--- a/src/Nupeek.Cli/ExitCodes.cs
+++ b/src/Nupeek.Cli/ExitCodes.cs
@@ -1,11 +1,25 @@
 namespace Nupeek.Cli;
 
+/// <summary>
+/// Stable process exit codes for CLI and automation consumers.
+/// </summary>
 public static class ExitCodes
 {
+    /// <summary>Command completed successfully.</summary>
     public const int Success = 0;
+
+    /// <summary>Unexpected or unclassified failure.</summary>
     public const int GenericError = 1;
+
+    /// <summary>Invalid user input or command arguments.</summary>
     public const int InvalidArguments = 2;
+
+    /// <summary>Package acquisition or package metadata resolution failure.</summary>
     public const int PackageResolutionFailure = 3;
+
+    /// <summary>Requested type/symbol could not be resolved in package content.</summary>
     public const int TypeOrSymbolNotFound = 4;
+
+    /// <summary>Failure while decompiling or writing generated output.</summary>
     public const int DecompilationFailure = 5;
 }

--- a/src/Nupeek.Cli/Program.cs
+++ b/src/Nupeek.Cli/Program.cs
@@ -1,3 +1,4 @@
 using Nupeek.Cli;
 
+// Minimal top-level entrypoint delegates to CliApp for testable command wiring.
 return await CliApp.RunAsync(args).ConfigureAwait(false);

--- a/src/Nupeek.Core/Models/ManifestEntry.cs
+++ b/src/Nupeek.Core/Models/ManifestEntry.cs
@@ -1,5 +1,15 @@
 namespace Nupeek.Core.Models;
 
+/// <summary>
+/// Provenance entry for one generated decompiled type.
+/// </summary>
+/// <param name="PackageId">Package id source.</param>
+/// <param name="Version">Package version source.</param>
+/// <param name="Tfm">TFM used for decompilation.</param>
+/// <param name="TypeName">Fully-qualified type name.</param>
+/// <param name="AssemblyPath">Assembly path where type was found.</param>
+/// <param name="OutputPath">Generated output file path.</param>
+/// <param name="DecompiledAtUtc">UTC timestamp when output was generated.</param>
 public sealed record ManifestEntry(
     string PackageId,
     string Version,

--- a/src/Nupeek.Core/Models/TypeIndex.cs
+++ b/src/Nupeek.Core/Models/TypeIndex.cs
@@ -1,5 +1,8 @@
 namespace Nupeek.Core.Models;
 
+/// <summary>
+/// Type-to-output-path lookup map persisted in <c>index.json</c>.
+/// </summary>
 public sealed class TypeIndex : Dictionary<string, string>
 {
 }

--- a/src/Nupeek.Core/NuGetCacheLayout.cs
+++ b/src/Nupeek.Core/NuGetCacheLayout.cs
@@ -1,13 +1,25 @@
 namespace Nupeek.Core;
 
+/// <summary>
+/// Provides deterministic cache path conventions for package artifacts.
+/// </summary>
 public static class NuGetCacheLayout
 {
+    /// <summary>
+    /// Gets the package/version cache directory.
+    /// </summary>
     public static string PackageDirectory(string cacheRoot, string packageId, string version)
         => Path.Combine(cacheRoot, "packages", packageId.ToLowerInvariant(), version);
 
+    /// <summary>
+    /// Gets the expected path to the downloaded <c>.nupkg</c> file.
+    /// </summary>
     public static string NupkgPath(string cacheRoot, string packageId, string version)
         => Path.Combine(PackageDirectory(cacheRoot, packageId, version), $"{packageId.ToLowerInvariant()}.{version}.nupkg");
 
+    /// <summary>
+    /// Gets the extraction target directory for package contents.
+    /// </summary>
     public static string ExtractedPath(string cacheRoot, string packageId, string version)
         => Path.Combine(PackageDirectory(cacheRoot, packageId, version), "extracted");
 }

--- a/src/Nupeek.Core/NuGetPackageRequest.cs
+++ b/src/Nupeek.Core/NuGetPackageRequest.cs
@@ -1,5 +1,11 @@
 namespace Nupeek.Core;
 
+/// <summary>
+/// Input for acquiring a NuGet package into local cache.
+/// </summary>
+/// <param name="PackageId">Package identifier (for example, <c>Humanizer.Core</c>).</param>
+/// <param name="Version">Optional explicit package version. If null, latest stable is selected.</param>
+/// <param name="CacheRoot">Root cache folder where package artifacts are stored.</param>
 public sealed record NuGetPackageRequest(
     string PackageId,
     string? Version,

--- a/src/Nupeek.Core/NuGetPackageResult.cs
+++ b/src/Nupeek.Core/NuGetPackageResult.cs
@@ -1,5 +1,13 @@
 namespace Nupeek.Core;
 
+/// <summary>
+/// Result of NuGet package acquisition and extraction.
+/// </summary>
+/// <param name="PackageId">Resolved package id.</param>
+/// <param name="Version">Resolved package version.</param>
+/// <param name="PackageDirectory">Deterministic cache folder for this package/version.</param>
+/// <param name="NupkgPath">Full path to downloaded <c>.nupkg</c> file.</param>
+/// <param name="ExtractedPath">Full path to extracted package contents.</param>
 public sealed record NuGetPackageResult(
     string PackageId,
     string Version,

--- a/src/Nupeek.Core/OutputCatalogWriter.cs
+++ b/src/Nupeek.Core/OutputCatalogWriter.cs
@@ -3,32 +3,46 @@ using System.Text.Json;
 
 namespace Nupeek.Core;
 
+/// <summary>
+/// Reads and updates output catalogs (<c>index.json</c> and <c>manifest.json</c>).
+/// </summary>
 public sealed class OutputCatalogWriter
 {
-    // Maintains index/manifest files used by agents and follow-up CLI commands.
     private static readonly JsonSerializerOptions JsonOptions = new()
     {
         WriteIndented = true,
     };
 
+    /// <summary>
+    /// Upserts type-to-output-path mapping in <c>index.json</c>.
+    /// </summary>
     public string WriteIndex(string outputRoot, string typeName, string outputPath)
     {
         var indexPath = Path.Combine(outputRoot, "index.json");
         Directory.CreateDirectory(outputRoot);
 
+        // Read existing index if present, otherwise start a new map.
         var index = ReadJson<TypeIndex>(indexPath) ?? new TypeIndex();
+
+        // Last write wins for the same type.
         index[typeName] = outputPath;
 
         File.WriteAllText(indexPath, JsonSerializer.Serialize(index, JsonOptions));
         return indexPath;
     }
 
+    /// <summary>
+    /// Upserts manifest entry in <c>manifest.json</c>.
+    /// </summary>
     public string WriteManifest(string outputRoot, ManifestEntry entry)
     {
         var manifestPath = Path.Combine(outputRoot, "manifest.json");
         Directory.CreateDirectory(outputRoot);
 
+        // Read existing manifest list if present.
         var manifest = ReadJson<List<ManifestEntry>>(manifestPath) ?? [];
+
+        // Unique key: package/version/tfm/type.
         var existingIndex = manifest.FindIndex(x =>
             string.Equals(x.PackageId, entry.PackageId, StringComparison.OrdinalIgnoreCase)
             && string.Equals(x.Version, entry.Version, StringComparison.Ordinal)
@@ -48,6 +62,9 @@ public sealed class OutputCatalogWriter
         return manifestPath;
     }
 
+    /// <summary>
+    /// Reads JSON file into target type. Returns default when file is missing/empty.
+    /// </summary>
     private static T? ReadJson<T>(string path)
     {
         if (!File.Exists(path))

--- a/src/Nupeek.Core/OutputPathBuilder.cs
+++ b/src/Nupeek.Core/OutputPathBuilder.cs
@@ -1,7 +1,13 @@
 namespace Nupeek.Core;
 
+/// <summary>
+/// Builds deterministic file paths for generated decompiled type output.
+/// </summary>
 public static class OutputPathBuilder
 {
+    /// <summary>
+    /// Builds the output file path for a single decompiled type.
+    /// </summary>
     public static string BuildTypeOutputPath(string root, string packageId, string version, string tfm, string fullTypeName)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(root);
@@ -10,10 +16,16 @@ public static class OutputPathBuilder
         ArgumentException.ThrowIfNullOrWhiteSpace(tfm);
         ArgumentException.ThrowIfNullOrWhiteSpace(fullTypeName);
 
+        // Keep filename human-readable while avoiding invalid filesystem characters.
         var fileName = SanitizeFileName(fullTypeName.Replace('.', '_')) + ".decompiled.cs";
+
+        // Layout is intentionally stable for indexing and repeat runs.
         return Path.Combine(root, "packages", packageId.ToLowerInvariant(), version, tfm, fileName);
     }
 
+    /// <summary>
+    /// Replaces unsupported characters with underscores for safe file names.
+    /// </summary>
     private static string SanitizeFileName(string value)
     {
         var chars = value

--- a/src/Nupeek.Core/PackageContentRequest.cs
+++ b/src/Nupeek.Core/PackageContentRequest.cs
@@ -1,5 +1,11 @@
 namespace Nupeek.Core;
 
+/// <summary>
+/// Input for resolving package content location for a target type.
+/// </summary>
+/// <param name="ExtractedPath">Root path of extracted package content.</param>
+/// <param name="FullTypeName">Fully-qualified type name to locate.</param>
+/// <param name="Tfm">Optional explicit TFM. If null, selector chooses best available.</param>
 public sealed record PackageContentRequest(
     string ExtractedPath,
     string FullTypeName,

--- a/src/Nupeek.Core/PackageContentResult.cs
+++ b/src/Nupeek.Core/PackageContentResult.cs
@@ -1,5 +1,12 @@
 namespace Nupeek.Core;
 
+/// <summary>
+/// Resolved package content details for a specific type.
+/// </summary>
+/// <param name="SelectedTfm">TFM selected for lookup/decompilation.</param>
+/// <param name="LibDirectory">Selected <c>lib/&lt;tfm&gt;</c> directory.</param>
+/// <param name="AssemblyPath">Assembly path containing target type.</param>
+/// <param name="FullTypeName">Resolved fully-qualified type name.</param>
 public sealed record PackageContentResult(
     string SelectedTfm,
     string LibDirectory,

--- a/src/Nupeek.Core/PackageTypeLocator.cs
+++ b/src/Nupeek.Core/PackageTypeLocator.cs
@@ -3,20 +3,27 @@ using System.Reflection.PortableExecutable;
 
 namespace Nupeek.Core;
 
+/// <summary>
+/// Resolves TFM/lib directory and locates assembly containing a target type.
+/// </summary>
 public sealed class PackageTypeLocator
 {
-    // Resolves the best lib/TFM directory and finds the assembly that defines a target type.
+    /// <summary>
+    /// Locates package content (TFM/lib/assembly) for the requested type.
+    /// </summary>
     public PackageContentResult Locate(PackageContentRequest request)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(request.ExtractedPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.FullTypeName);
 
+        // NuGet library binaries are expected under extracted/lib/<tfm>/.
         var libRoot = Path.Combine(request.ExtractedPath, "lib");
         if (!Directory.Exists(libRoot))
         {
             throw new InvalidOperationException($"Package does not contain a lib folder: {libRoot}");
         }
 
+        // Enumerate available TFMs in package.
         var tfmDirectories = Directory.GetDirectories(libRoot)
             .Select(Path.GetFileName)
             .Where(static x => !string.IsNullOrWhiteSpace(x))
@@ -28,7 +35,7 @@ public sealed class PackageTypeLocator
             throw new InvalidOperationException($"No target frameworks found under: {libRoot}");
         }
 
-        // If user does not specify TFM, pick best known target for current runtime/tooling.
+        // Respect explicit TFM; otherwise auto-select best candidate.
         var selectedTfm = string.IsNullOrWhiteSpace(request.Tfm)
             ? TfmSelector.SelectBest(tfmDirectories)
             : request.Tfm.Trim();
@@ -39,12 +46,16 @@ public sealed class PackageTypeLocator
             throw new InvalidOperationException($"Requested TFM '{selectedTfm}' not found in package.");
         }
 
+        // Metadata scan each managed assembly to find the declaring type.
         var assemblyPath = FindAssemblyContainingType(selectedLibDir, request.FullTypeName)
             ?? throw new InvalidOperationException($"Type '{request.FullTypeName}' was not found in '{selectedLibDir}'.");
 
         return new PackageContentResult(selectedTfm, selectedLibDir, assemblyPath, request.FullTypeName);
     }
 
+    /// <summary>
+    /// Returns first assembly path that defines <paramref name="fullTypeName"/>.
+    /// </summary>
     private static string? FindAssemblyContainingType(string libDir, string fullTypeName)
     {
         foreach (var dll in Directory.GetFiles(libDir, "*.dll"))
@@ -54,6 +65,7 @@ public sealed class PackageTypeLocator
                 using var stream = File.OpenRead(dll);
                 using var peReader = new PEReader(stream);
 
+                // Skip native or invalid binaries without CLI metadata.
                 if (!peReader.HasMetadata)
                 {
                     continue;
@@ -75,7 +87,7 @@ public sealed class PackageTypeLocator
             }
             catch
             {
-                // Skip non-managed or unreadable binaries.
+                // Ignore unreadable/unmanaged assemblies and continue scanning.
             }
         }
 

--- a/src/Nupeek.Core/SymbolParser.cs
+++ b/src/Nupeek.Core/SymbolParser.cs
@@ -1,7 +1,16 @@
 namespace Nupeek.Core;
 
+/// <summary>
+/// Converts symbol-like inputs (for example, <c>Namespace.Type.Method</c>) into type names.
+/// </summary>
 public static class SymbolParser
 {
+    /// <summary>
+    /// Returns a type name derived from the provided symbol text.
+    /// </summary>
+    /// <remarks>
+    /// If the input appears to include a member suffix, only the type part is returned.
+    /// </remarks>
     public static string ToTypeName(string symbol)
     {
         if (string.IsNullOrWhiteSpace(symbol))
@@ -9,7 +18,10 @@ public static class SymbolParser
             throw new ArgumentException("Symbol is required", nameof(symbol));
         }
 
+        // Normalize whitespace around user-provided input.
         var clean = symbol.Trim();
+
+        // Heuristic: strip last segment as member name when dot-separated.
         var lastDot = clean.LastIndexOf('.');
         if (lastDot <= 0)
         {

--- a/src/Nupeek.Core/TfmSelector.cs
+++ b/src/Nupeek.Core/TfmSelector.cs
@@ -1,12 +1,19 @@
 namespace Nupeek.Core;
 
+/// <summary>
+/// Selects the most suitable TFM from available package targets.
+/// </summary>
 public static class TfmSelector
 {
+    // Priority order tuned for current Nupeek runtime expectations.
     private static readonly string[] Priority =
     [
         "net10.0", "net9.0", "net8.0", "net7.0", "net6.0", "netstandard2.1", "netstandard2.0"
     ];
 
+    /// <summary>
+    /// Picks the best TFM from the candidate set.
+    /// </summary>
     public static string SelectBest(IEnumerable<string> tfms)
     {
         var available = tfms?.Distinct(StringComparer.OrdinalIgnoreCase).ToList()
@@ -17,6 +24,7 @@ public static class TfmSelector
             throw new ArgumentException("At least one TFM must be provided", nameof(tfms));
         }
 
+        // First pass: preferred known TFMs.
         foreach (var preferred in Priority)
         {
             var found = available.FirstOrDefault(x => string.Equals(x, preferred, StringComparison.OrdinalIgnoreCase));
@@ -26,6 +34,7 @@ public static class TfmSelector
             }
         }
 
+        // Fallback keeps deterministic behavior even for unknown/custom TFMs.
         return available.OrderBy(x => x, StringComparer.OrdinalIgnoreCase).First();
     }
 }

--- a/src/Nupeek.Core/TypeDecompilePipeline.cs
+++ b/src/Nupeek.Core/TypeDecompilePipeline.cs
@@ -2,19 +2,27 @@ using Nupeek.Core.Models;
 
 namespace Nupeek.Core;
 
+/// <summary>
+/// Orchestrates end-to-end decompilation flow for one type request.
+/// </summary>
 public sealed class TypeDecompilePipeline
 {
-    // Orchestrates end-to-end decompilation for one type.
     private readonly NuGetPackageAcquirer _acquirer;
     private readonly PackageTypeLocator _locator;
     private readonly TypeDecompiler _decompiler;
     private readonly OutputCatalogWriter _catalogWriter;
 
+    /// <summary>
+    /// Creates pipeline with default concrete services.
+    /// </summary>
     public TypeDecompilePipeline()
         : this(new NuGetPackageAcquirer(), new PackageTypeLocator(), new TypeDecompiler(), new OutputCatalogWriter())
     {
     }
 
+    /// <summary>
+    /// Creates pipeline with explicit service dependencies.
+    /// </summary>
     public TypeDecompilePipeline(
         NuGetPackageAcquirer acquirer,
         PackageTypeLocator locator,
@@ -27,24 +35,28 @@ public sealed class TypeDecompilePipeline
         _catalogWriter = catalogWriter;
     }
 
+    /// <summary>
+    /// Executes package acquisition, type location, decompilation, and catalog updates.
+    /// </summary>
     public async Task<TypeDecompileResult> RunAsync(TypeDecompileRequest request, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(request.PackageId);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.TypeName);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.OutputRoot);
 
-        // Keep package artifacts in a deterministic cache under output root.
+        // Keep package artifacts under output root so the run is self-contained.
         var cacheRoot = Path.Combine(request.OutputRoot, ".cache");
 
-        // 1) Acquire and extract package.
+        // 1) Acquire package and extracted content.
         var package = await _acquirer.AcquireAsync(new NuGetPackageRequest(request.PackageId, request.Version, cacheRoot), cancellationToken).ConfigureAwait(false);
 
-        // 2) Resolve TFM/lib and locate the assembly containing the target type.
+        // 2) Resolve lib/TFM and assembly containing target type.
         var content = _locator.Locate(new PackageContentRequest(
             package.ExtractedPath,
             request.TypeName,
             request.Tfm));
 
+        // 3) Compute deterministic output file path.
         var outputPath = OutputPathBuilder.BuildTypeOutputPath(
             request.OutputRoot,
             package.PackageId,
@@ -52,10 +64,10 @@ public sealed class TypeDecompilePipeline
             content.SelectedTfm,
             request.TypeName);
 
-        // 3) Decompile the type into a stable output location.
+        // 4) Decompile target type into generated C# file.
         _decompiler.DecompileType(content.AssemblyPath, request.TypeName, outputPath);
 
-        // 4) Update machine-readable catalogs for fast lookup and provenance.
+        // 5) Update index and manifest for downstream tooling.
         var indexPath = _catalogWriter.WriteIndex(request.OutputRoot, request.TypeName, outputPath);
         var manifestPath = _catalogWriter.WriteManifest(request.OutputRoot, new ManifestEntry(
             package.PackageId,

--- a/src/Nupeek.Core/TypeDecompileRequest.cs
+++ b/src/Nupeek.Core/TypeDecompileRequest.cs
@@ -1,5 +1,13 @@
 namespace Nupeek.Core;
 
+/// <summary>
+/// Input contract for end-to-end decompilation of a single type.
+/// </summary>
+/// <param name="PackageId">NuGet package id.</param>
+/// <param name="Version">Optional package version. If null, latest stable is used.</param>
+/// <param name="Tfm">Optional target framework. If null, best available is selected.</param>
+/// <param name="TypeName">Fully-qualified target type name to decompile.</param>
+/// <param name="OutputRoot">Output root for generated source and catalogs.</param>
 public sealed record TypeDecompileRequest(
     string PackageId,
     string? Version,

--- a/src/Nupeek.Core/TypeDecompileResult.cs
+++ b/src/Nupeek.Core/TypeDecompileResult.cs
@@ -1,5 +1,16 @@
 namespace Nupeek.Core;
 
+/// <summary>
+/// Output contract for a successful type decompilation run.
+/// </summary>
+/// <param name="PackageId">Resolved package id.</param>
+/// <param name="Version">Resolved package version.</param>
+/// <param name="Tfm">Resolved target framework used for lookup.</param>
+/// <param name="TypeName">Target type that was decompiled.</param>
+/// <param name="AssemblyPath">Assembly path used for decompilation.</param>
+/// <param name="OutputPath">Generated decompiled source file path.</param>
+/// <param name="IndexPath">Updated type index file path.</param>
+/// <param name="ManifestPath">Updated manifest file path.</param>
 public sealed record TypeDecompileResult(
     string PackageId,
     string Version,

--- a/src/Nupeek.Core/TypeDecompiler.cs
+++ b/src/Nupeek.Core/TypeDecompiler.cs
@@ -4,14 +4,21 @@ using ICSharpCode.Decompiler.TypeSystem;
 
 namespace Nupeek.Core;
 
+/// <summary>
+/// Decompiles a single CLR type from an assembly into C# source.
+/// </summary>
 public sealed class TypeDecompiler
 {
+    /// <summary>
+    /// Decompiles the requested type and writes the generated source to disk.
+    /// </summary>
     public void DecompileType(string assemblyPath, string fullTypeName, string outputPath)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(assemblyPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(fullTypeName);
         ArgumentException.ThrowIfNullOrWhiteSpace(outputPath);
 
+        // Conservative defaults prioritize resilience over strict reference resolution.
         var settings = new DecompilerSettings
         {
             ThrowOnAssemblyResolveErrors = false,
@@ -19,9 +26,11 @@ public sealed class TypeDecompiler
             UsingDeclarations = true,
         };
 
+        // Build decompiler for target assembly and type.
         var decompiler = new CSharpDecompiler(assemblyPath, settings);
         var syntax = decompiler.DecompileType(new FullTypeName(fullTypeName));
 
+        // Ensure destination folder exists before writing source output.
         var directory = Path.GetDirectoryName(outputPath)
             ?? throw new InvalidOperationException("Output path directory is missing.");
 


### PR DESCRIPTION
## Summary
Add detailed comments across source as requested:

- class-level XML summaries
- method-level XML summaries
- inline step comments in non-trivial method flows

## Scope covered
- CLI layer (`CliApp`, `ExitCodes`, `Program`)
- Core pipeline/services/models/helpers
- Request/result contracts and catalog/path helpers

## Validation
- `dotnet format Nupeek.slnx`
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`

## Related
Closes #20
