### PR TITLE
✨ feat(release): package Nupeek as a .NET global tool

### DIFF
--- a/src/Nupeek.Cli/Nupeek.Cli.csproj
+++ b/src/Nupeek.Cli/Nupeek.Cli.csproj
@@ -4,9 +4,24 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
+
+    <PackAsTool>true</PackAsTool>
+    <ToolCommandName>nupeek</ToolCommandName>
+    <PackageId>Nupeek</PackageId>
+    <Version>0.1.0</Version>
+    <Authors>ghostmxvlshn</Authors>
+    <Description>Targeted NuGet decompilation for coding agents.</Description>
+    <PackageTags>nuget;decompile;cli;dotnet-tool</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <RepositoryUrl>https://github.com/ghostmxvlshn/nupeek</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
   </PropertyGroup>
   <ItemGroup>
     <ProjectReference Include="..\Nupeek.Core\Nupeek.Core.csproj" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="README.md" Pack="true" PackagePath="\" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="System.CommandLine" />

--- a/src/Nupeek.Cli/README.md
+++ b/src/Nupeek.Cli/README.md
@@ -1,0 +1,10 @@
+# Nupeek (.NET Tool)
+
+Nupeek is a CLI for targeted NuGet type decompilation.
+
+## Usage
+
+```bash
+nupeek --help
+nupeek type --package Azure.Messaging.ServiceBus --type Azure.Messaging.ServiceBus.ServiceBusSender --out deps-src
+```


### PR DESCRIPTION
## Summary
Package Nupeek as a .NET global tool.

## Changes
- Configure `Nupeek.Cli` as tool package:
  - `PackAsTool=true`
  - `ToolCommandName=nupeek`
  - package metadata (id/version/description/repo/license/tags)
- Add `src/Nupeek.Cli/README.md` and include it in package.

## Validation
- `dotnet restore Nupeek.slnx`
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`
- `dotnet pack src/Nupeek.Cli/Nupeek.Cli.csproj -c Release --no-build -o ./artifacts`
- `dotnet tool install Nupeek --add-source ./artifacts --tool-path ./.tmp-tools`
- `./.tmp-tools/nupeek --help`

## Related
Closes #22
