### PR TITLE
📝 docs(install): add global/local installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ deps-src/
 - CLI UX standards: `docs/CLI_BEST_PRACTICES.md` (derived from https://clig.dev)
 - C# style rules: `.editorconfig`
 - Central package management: `Directory.Packages.props`
+- Install guide: `docs/INSTALL.md`
 
 ## Git hooks (recommended)
 Install local hooks once per clone:

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -1,0 +1,64 @@
+# Install Nupeek
+
+## Prerequisites
+
+- .NET SDK 10+
+
+Verify:
+
+```bash
+dotnet --list-sdks
+```
+
+## Option 1: Global install (recommended)
+
+```bash
+dotnet tool install -g Nupeek
+```
+
+Update later:
+
+```bash
+dotnet tool update -g Nupeek
+```
+
+Verify:
+
+```bash
+nupeek --help
+```
+
+## Option 2: Local (repo-scoped) tool install
+
+```bash
+dotnet new tool-manifest
+# Package name and command name may differ; command remains `nupeek`
+dotnet tool install Nupeek
+```
+
+Restore in CI/other machines:
+
+```bash
+dotnet tool restore
+```
+
+Run:
+
+```bash
+dotnet nupeek --help
+```
+
+## Quick smoke test
+
+```bash
+nupeek type \
+  --package Azure.Messaging.ServiceBus \
+  --type Azure.Messaging.ServiceBus.ServiceBusSender \
+  --out deps-src \
+  --dry-run false
+```
+
+Expected outputs:
+- generated source under `deps-src/packages/...`
+- `deps-src/index.json`
+- `deps-src/manifest.json`


### PR DESCRIPTION
## Summary
Add installation documentation for Nupeek global/local tool usage.

## Changes
- Added `docs/INSTALL.md` with:
  - prerequisites
  - global install/update commands
  - local tool-manifest install
  - verification and smoke test
- Linked install guide from README

## Validation
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`

## Related
Closes #23
