### PR TITLE
🚀 ci(release): add tag-based NuGet publish workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,50 @@
+name: release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup .NET 10
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 10.0.x
+
+      - name: Restore
+        run: dotnet restore Nupeek.slnx
+
+      - name: Build
+        run: dotnet build Nupeek.slnx --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test Nupeek.slnx --configuration Release --no-build
+
+      - name: Pack tool
+        run: dotnet pack src/Nupeek.Cli/Nupeek.Cli.csproj --configuration Release --no-build --output ./artifacts
+
+      - name: Publish to NuGet
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          dotnet nuget push "./artifacts/*.nupkg" \
+            --api-key "$NUGET_API_KEY" \
+            --source "https://api.nuget.org/v3/index.json" \
+            --skip-duplicate
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh release create "${GITHUB_REF_NAME}" ./artifacts/*.nupkg \
+            --title "${GITHUB_REF_NAME}" \
+            --notes "Nupeek release ${GITHUB_REF_NAME}"

--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ deps-src/
 - C# style rules: `.editorconfig`
 - Central package management: `Directory.Packages.props`
 - Install guide: `docs/INSTALL.md`
+- Release guide: `docs/RELEASE.md`
 
 ## Git hooks (recommended)
 Install local hooks once per clone:

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -1,0 +1,32 @@
+# Release Nupeek
+
+## Required repository secrets
+
+- `NUGET_API_KEY` — API key with push permissions for NuGet.org
+
+## Versioning
+
+1. Update package version in `src/Nupeek.Cli/Nupeek.Cli.csproj`.
+2. Commit changes.
+3. Create and push a tag:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+## What happens on tag push
+
+Workflow: `.github/workflows/release.yml`
+
+- restore, build, test
+- pack Nupeek global tool package
+- publish package to NuGet.org
+- create GitHub release and attach `.nupkg`
+
+## Verify published package
+
+```bash
+dotnet tool update -g Nupeek
+nupeek --help
+```


### PR DESCRIPTION
## Summary
Add release automation workflow for tag-based NuGet publishing.

## Changes
- Added `.github/workflows/release.yml`:
  - trigger on `v*` tags
  - restore/build/test/pack
  - publish nupkg to NuGet.org via `NUGET_API_KEY`
  - create GitHub release with nupkg attached
- Added `docs/RELEASE.md` with release steps and required secrets
- Linked release guide in README

## Validation
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`

## Related
Closes #24
