### PR TITLE
🔧 feat(installer): add curl|sh install script with version pinning

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@ obj/
 *.suo
 .DS_Store
 deps-src/
+.tmp-tools/
+artifacts/
+.tmp-tools/

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ deps-src/
 - CLI UX standards: `docs/CLI_BEST_PRACTICES.md` (derived from https://clig.dev)
 - C# style rules: `.editorconfig`
 - Central package management: `Directory.Packages.props`
-- Install guide: `docs/INSTALL.md`
+- Install guide: `docs/INSTALL.md` (includes curl|sh installer)
 - Release guide: `docs/RELEASE.md`
 
 ## Git hooks (recommended)

--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -16,6 +16,18 @@ dotnet --list-sdks
 dotnet tool install -g Nupeek
 ```
 
+### One-line installer (curl | sh)
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ghostmxvlshn/nupeek/main/install.sh | bash
+```
+
+Pin a version:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/ghostmxvlshn/nupeek/main/install.sh | VERSION=0.1.0 bash
+```
+
 Update later:
 
 ```bash

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PACKAGE_ID="Nupeek"
+VERSION="${VERSION:-}"
+TOOLS_PATH="${TOOLS_PATH:-$HOME/.dotnet/tools}"
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+log() {
+  printf '[nupeek-install] %s\n' "$*"
+}
+
+if ! has_cmd dotnet; then
+  log "dotnet SDK is required but was not found in PATH."
+  log "Install .NET SDK 10+ first: https://dotnet.microsoft.com/download"
+  exit 1
+fi
+
+if dotnet tool list -g | awk 'NR>2 {print $1}' | grep -qi '^nupeek$'; then
+  if [[ -n "$VERSION" ]]; then
+    log "Updating $PACKAGE_ID to version $VERSION"
+    dotnet tool update -g "$PACKAGE_ID" --version "$VERSION"
+  else
+    log "Updating $PACKAGE_ID to latest"
+    dotnet tool update -g "$PACKAGE_ID"
+  fi
+else
+  if [[ -n "$VERSION" ]]; then
+    log "Installing $PACKAGE_ID version $VERSION"
+    dotnet tool install -g "$PACKAGE_ID" --version "$VERSION"
+  else
+    log "Installing $PACKAGE_ID latest"
+    dotnet tool install -g "$PACKAGE_ID"
+  fi
+fi
+
+if [[ ":$PATH:" != *":$TOOLS_PATH:"* ]]; then
+  log "Nupeek installed, but $TOOLS_PATH is not currently in PATH."
+  log "Add this to your shell profile:"
+  log "  export PATH=\"\$PATH:$TOOLS_PATH\""
+else
+  log "PATH already contains $TOOLS_PATH"
+fi
+
+if has_cmd nupeek; then
+  log "Install complete."
+  nupeek --help >/dev/null
+  log "Verified: nupeek --help"
+else
+  log "Nupeek command not visible in current shell yet. Open a new shell or update PATH."
+fi


### PR DESCRIPTION
## Summary
Add curl|sh installer script for Nupeek with optional version pinning.

## Changes
- Added `install.sh`:
  - validates dotnet availability
  - installs/updates global Nupeek tool
  - supports `VERSION=...` pinning
  - checks PATH guidance for `~/.dotnet/tools`
  - verifies `nupeek --help` when command is visible
- Updated install docs with curl|sh usage and version pinning examples
- Updated README install note
- Ignored local installer test folders/artifacts in `.gitignore`

## Validation
- `bash -n install.sh`
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`

## Related
Closes #25
