### PR TITLE
🔒 chore(repo): add CODEOWNERS baseline

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# Require owner review for all repository changes
+* @ghostmxvlshn


### PR DESCRIPTION
## Summary
Add CODEOWNERS baseline required for protected review workflow.

## Changes
- Added `.github/CODEOWNERS` with repository owner as code owner

## Validation
- `dotnet build Nupeek.slnx -c Release --no-restore`
- `dotnet test Nupeek.slnx -c Release --no-build`

## Related
Closes #33
