### PR TITLE
🔒 chore(repo): add @mxvlshn as additional code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 # Require owner review for all repository changes
-* @ghostmxvlshn
+* @ghostmxvlshn @mxvlshn


### PR DESCRIPTION
## Summary
Add @mxvlshn as additional code owner to support alternate-account approvals.

## Changes
- Updated `.github/CODEOWNERS` to include:
  - @ghostmxvlshn
  - @mxvlshn

## Related
Closes #37
