### PR TITLE
🚀 ci(web): deploy landing page with GitHub Pages + DNS guide

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,41 @@
+name: pages
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'web/**'
+      - '.github/workflows/pages.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: ./web
+
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -43,5 +43,6 @@ See: **`docs/INSTALL.md`**
 
 - Deep project/reference doc: **`docs/README_DEEP.md`**
 - Release process: `docs/RELEASE.md`
+- Hosting (GitHub Pages + DNS): `docs/HOSTING.md`
 - CLI UX standards: `docs/CLI_BEST_PRACTICES.md`
 - Landing page: `web/index.html`

--- a/docs/HOSTING.md
+++ b/docs/HOSTING.md
@@ -1,0 +1,57 @@
+# Hosting Nupeek Landing Page
+
+Nupeek uses GitHub Pages to host `web/`.
+
+## Deploy model
+
+- Workflow: `.github/workflows/pages.yml`
+- Trigger: push to `main` when `web/**` changes
+- Published directory: `web/`
+
+After first run, site URL will appear in:
+- GitHub repo → Settings → Pages
+- workflow job output (`deployment.page_url`)
+
+## Custom domain (optional)
+
+Recommended domain options:
+- `nupeek.dev`
+- `nupeek.tools`
+- `www.nupeek.dev`
+
+### DNS for apex/root domain (e.g., `nupeek.dev`)
+
+Add records:
+
+- `A` → `185.199.108.153`
+- `A` → `185.199.109.153`
+- `A` → `185.199.110.153`
+- `A` → `185.199.111.153`
+- `AAAA` → `2606:50c0:8000::153`
+- `AAAA` → `2606:50c0:8001::153`
+- `AAAA` → `2606:50c0:8002::153`
+- `AAAA` → `2606:50c0:8003::153`
+
+### DNS for `www` subdomain
+
+- `CNAME` → `<your-github-username>.github.io`
+
+For this repo owner:
+- `CNAME` → `ghostmxvlshn.github.io`
+
+## GitHub Pages settings
+
+1. Repo Settings → Pages
+2. Source: GitHub Actions
+3. (Optional) Set custom domain
+4. Enable "Enforce HTTPS"
+
+## Optional CNAME file
+
+If you decide on a domain, add `web/CNAME` containing one line, e.g.:
+
+```text
+nupeek.dev
+```
+
+Then commit/push and redeploy.


### PR DESCRIPTION
## Summary
Set up GitHub Pages deployment for Nupeek landing page and document DNS setup.

## Changes
- Added Pages workflow: `.github/workflows/pages.yml`
  - deploys `web/` on push to `main`
  - supports manual dispatch
- Added hosting doc: `docs/HOSTING.md`
  - GitHub Pages setup steps
  - DNS records for apex and www custom domains
  - optional `web/CNAME` instructions
- Linked hosting doc from `README.md`

## Related
Closes #39
