### PR TITLE
🐛 fix(cli): non-zero failure exit codes + SKILL.md command fix

### DIFF
--- a/tests/Nupeek.Cli.Tests/CliAppTests.cs
+++ b/tests/Nupeek.Cli.Tests/CliAppTests.cs
@@ -29,6 +29,29 @@ public class CliAppTests
     }
 
     [Fact]
+    public async Task RunAsync_TypeCommandFailure_ReturnsNonZeroExitCode()
+    {
+        // Arrange
+        var outDir = Path.Combine(Path.GetTempPath(), $"nupeek-cli-test-{Guid.NewGuid():N}");
+        var args = new[]
+        {
+            "type",
+            "--package", "../../pwned",
+            "--version", "1.0.0",
+            "--type", "A.B",
+            "--out", outDir,
+            "--dry-run", "false",
+            "--quiet",
+        };
+
+        // Act
+        var code = await CliApp.RunAsync(args);
+
+        // Assert
+        Assert.Equal(ExitCodes.DecompilationFailure, code);
+    }
+
+    [Fact]
     public void BuildPlanText_IncludesSymbolWhenProvided()
     {
         // Arrange

--- a/web/downloads/nupeek-agent-skill.md
+++ b/web/downloads/nupeek-agent-skill.md
@@ -34,7 +34,7 @@ nupeek type --package <PackageId> --type <Namespace.Type> --out deps-src
 3. If type is unknown, discover candidates:
 
 ```bash
-nupeek find --package <PackageId> --name <TypeOrPattern> --out deps-src
+nupeek find --package <PackageId> --symbol <Namespace.TypeOrMember> --out deps-src
 ```
 
 4. Inspect generated files under `deps-src/`:


### PR DESCRIPTION
## Summary
Fix immediate reliability blockers found in audit.

## What changed
- Fixed CLI command handlers so failures propagate as non-zero process exit codes
- Added CLI test to lock failure exit-code behavior
- Corrected downloadable skill command from `--name` to `--symbol`

## Validation
- pre-commit passed
- dotnet test passed
- manual repro now returns `code=5` for invalid package id failure

Closes #47