### PR TITLE
✨ feat(cli): add machine-readable --format json output contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,9 @@ So agents can reason from actual implementation details instead of guesswork.
 nupeek type --package Azure.Messaging.ServiceBus \
   --type Azure.Messaging.ServiceBus.ServiceBusSender \
   --out deps-src --dry-run false
+
+# machine-readable contract for agents/tools
+nupeek type --package Polly --type Polly.Policy --out deps-src --format json
 ```
 
 Output goes to:

--- a/docs/README_DEEP.md
+++ b/docs/README_DEEP.md
@@ -11,8 +11,8 @@ Without source visibility, agents often infer behavior from signatures/docs only
 ## Core commands
 
 ```bash
-nupeek type --package <id> [--version <v>] [--tfm <tfm>] --type "<Namespace.Type>" --out deps-src
-nupeek find --package <id> [--version <v>] [--tfm <tfm>] --symbol "<Namespace.Type.Method>" --out deps-src
+nupeek type --package <id> [--version <v>] [--tfm <tfm>] --type "<Namespace.Type>" --out deps-src [--format text|json]
+nupeek find --package <id> [--version <v>] [--tfm <tfm>] --symbol "<Namespace.Type.Method>" --out deps-src [--format text|json]
 ```
 
 ## Typical output layout

--- a/tests/Nupeek.Cli.Tests/CliAppTests.cs
+++ b/tests/Nupeek.Cli.Tests/CliAppTests.cs
@@ -1,3 +1,5 @@
+using System.Text.Json;
+
 namespace Nupeek.Cli.Tests;
 
 public class CliAppTests
@@ -49,6 +51,80 @@ public class CliAppTests
 
         // Assert
         Assert.Equal(ExitCodes.DecompilationFailure, code);
+    }
+
+    [Fact]
+    public async Task RunAsync_TypeDryRun_JsonFormat_WritesJsonPayload()
+    {
+        // Arrange
+        var args = new[]
+        {
+            "type",
+            "--package", "Polly",
+            "--type", "Polly.Policy",
+            "--out", "deps-src",
+            "--format", "json",
+        };
+
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+
+        try
+        {
+            // Act
+            var code = await CliApp.RunAsync(args);
+
+            // Assert
+            Assert.Equal(ExitCodes.Success, code);
+            var payload = JsonDocument.Parse(writer.ToString());
+            Assert.Equal("type", payload.RootElement.GetProperty("Command").GetString());
+            Assert.Equal("Polly", payload.RootElement.GetProperty("PackageId").GetString());
+            Assert.Equal("Polly.Policy", payload.RootElement.GetProperty("InputType").GetString());
+            Assert.Equal(0, payload.RootElement.GetProperty("ExitCode").GetInt32());
+            Assert.True(payload.RootElement.GetProperty("DryRun").GetBoolean());
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
+    }
+
+    [Fact]
+    public async Task RunAsync_TypeFailure_JsonFormat_WritesJsonErrorPayload()
+    {
+        // Arrange
+        var outDir = Path.Combine(Path.GetTempPath(), $"nupeek-cli-test-{Guid.NewGuid():N}");
+        var args = new[]
+        {
+            "type",
+            "--package", "../../pwned",
+            "--version", "1.0.0",
+            "--type", "A.B",
+            "--out", outDir,
+            "--dry-run", "false",
+            "--format", "json",
+        };
+
+        var originalOut = Console.Out;
+        using var writer = new StringWriter();
+        Console.SetOut(writer);
+
+        try
+        {
+            // Act
+            var code = await CliApp.RunAsync(args);
+
+            // Assert
+            Assert.Equal(ExitCodes.DecompilationFailure, code);
+            var payload = JsonDocument.Parse(writer.ToString());
+            Assert.Equal(ExitCodes.DecompilationFailure, payload.RootElement.GetProperty("ExitCode").GetInt32());
+            Assert.False(string.IsNullOrWhiteSpace(payload.RootElement.GetProperty("Error").GetString()));
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+        }
     }
 
     [Fact]


### PR DESCRIPTION
## Summary
Add first-class machine-readable JSON output for `type` and `find` commands.

## What changed
- Added `--format text|json` on both `type` and `find` commands
- Added stable JSON payload for dry-run, success, and failure paths
- Preserved current text output as default behavior (`--format text`)
- Kept non-zero exit codes for failures, including in JSON mode
- Added CLI tests for:
  - dry-run JSON success payload
  - JSON failure payload + non-zero exit code
- Updated docs to include `--format` usage

## JSON payload fields
- `Command`
- `PackageId`
- `Version`
- `SelectedTfm`
- `InputType` / `InputSymbol`
- `ResolvedType`
- `AssemblyPath`
- `OutputPath`
- `IndexPath`
- `ManifestPath`
- `DryRun`
- `ExitCode`
- `Error`

## Validation
- pre-commit passed
- dotnet test passed
- manual check verified JSON-only stdout and non-zero failures

Closes #51