### PR TITLE
🚀 ci(release): auto-publish on every main change

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,8 +2,7 @@ name: release
 
 on:
   push:
-    tags:
-      - 'v*'
+    branches: [ main ]
 
 jobs:
   publish:
@@ -20,6 +19,25 @@ jobs:
         with:
           dotnet-version: 10.0.x
 
+      - name: Compute version
+        id: version
+        shell: bash
+        run: |
+          VERSION_PREFIX=$(sed -n 's:.*<VersionPrefix>\(.*\)</VersionPrefix>.*:\1:p' src/Nupeek.Cli/Nupeek.Cli.csproj | head -n 1)
+          if [ -z "$VERSION_PREFIX" ]; then
+            echo "VersionPrefix not found in src/Nupeek.Cli/Nupeek.Cli.csproj"
+            exit 1
+          fi
+
+          PACKAGE_VERSION="${VERSION_PREFIX}.${GITHUB_RUN_NUMBER}"
+          TAG_NAME="v${PACKAGE_VERSION}"
+
+          echo "package_version=$PACKAGE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag_name=$TAG_NAME" >> "$GITHUB_OUTPUT"
+
+          echo "Computed package version: $PACKAGE_VERSION"
+          echo "Computed release tag: $TAG_NAME"
+
       - name: Restore
         run: dotnet restore Nupeek.slnx
 
@@ -30,7 +48,12 @@ jobs:
         run: dotnet test Nupeek.slnx --configuration Release --no-build
 
       - name: Pack tool
-        run: dotnet pack src/Nupeek.Cli/Nupeek.Cli.csproj --configuration Release --no-build --output ./artifacts
+        run: |
+          dotnet pack src/Nupeek.Cli/Nupeek.Cli.csproj \
+            --configuration Release \
+            --no-build \
+            --output ./artifacts \
+            /p:Version=${{ steps.version.outputs.package_version }}
 
       - name: Publish to NuGet
         env:
@@ -41,10 +64,17 @@ jobs:
             --source "https://api.nuget.org/v3/index.json" \
             --skip-duplicate
 
+      - name: Create and push tag
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag "${{ steps.version.outputs.tag_name }}"
+          git push origin "${{ steps.version.outputs.tag_name }}"
+
       - name: Create GitHub Release
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          gh release create "${GITHUB_REF_NAME}" ./artifacts/*.nupkg \
-            --title "${GITHUB_REF_NAME}" \
-            --notes "Nupeek release ${GITHUB_REF_NAME}"
+          gh release create "${{ steps.version.outputs.tag_name }}" ./artifacts/*.nupkg \
+            --title "${{ steps.version.outputs.tag_name }}" \
+            --notes "Nupeek release ${{ steps.version.outputs.tag_name }}"

--- a/docs/RELEASE.md
+++ b/docs/RELEASE.md
@@ -4,25 +4,33 @@
 
 - `NUGET_API_KEY` — API key with push permissions for NuGet.org
 
-## Versioning
+## Automatic release model
 
-1. Update package version in `src/Nupeek.Cli/Nupeek.Cli.csproj`.
-2. Commit changes.
-3. Create and push a tag:
-
-```bash
-git tag v0.1.0
-git push origin v0.1.0
-```
-
-## What happens on tag push
+Nupeek now releases automatically on every push to `main`.
 
 Workflow: `.github/workflows/release.yml`
 
-- restore, build, test
-- pack Nupeek global tool package
-- publish package to NuGet.org
-- create GitHub release and attach `.nupkg`
+What it does on each `main` push:
+
+1. restore, build, test
+2. compute package version from:
+   - `<VersionPrefix>` in `src/Nupeek.Cli/Nupeek.Cli.csproj`
+   - `github.run_number`
+3. pack Nupeek global tool package with computed version
+4. publish package to NuGet.org
+5. create and push git tag `v<computed-version>`
+6. create GitHub release and attach `.nupkg`
+
+## Version format
+
+`<VersionPrefix>.<github.run_number>`
+
+Example:
+
+- `VersionPrefix=0.1`
+- workflow run number `127`
+- published version: `0.1.127`
+- tag: `v0.1.127`
 
 ## Verify published package
 
@@ -30,3 +38,7 @@ Workflow: `.github/workflows/release.yml`
 dotnet tool update -g Nupeek
 nupeek --help
 ```
+
+## Manual fallback
+
+If automatic release is temporarily disabled, run the same pack/push steps manually and publish a matching GitHub release tag.

--- a/src/Nupeek.Cli/Nupeek.Cli.csproj
+++ b/src/Nupeek.Cli/Nupeek.Cli.csproj
@@ -8,7 +8,7 @@
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>nupeek</ToolCommandName>
     <PackageId>Nupeek</PackageId>
-    <Version>0.1.0</Version>
+    <VersionPrefix>0.1</VersionPrefix>
     <Authors>ghostmxvlshn</Authors>
     <Description>Targeted NuGet decompilation for coding agents.</Description>
     <PackageTags>nuget;decompile;cli;dotnet-tool</PackageTags>


### PR DESCRIPTION
## Summary
Automate Nupeek releases so every merge to main publishes a new package and GitHub release.

## What changed
- Switched release workflow trigger from tags to push on main
- Added automatic version computation:
  - VersionPrefix (from csproj) + github.run_number
- Pack now uses computed version via /p:Version=...
- Workflow now auto-creates and pushes a matching release tag (v<version>)
- Updated release documentation for the new automatic model
- Replaced fixed Version with VersionPrefix in CLI project

## Why
- Removes manual tag/release steps
- Guarantees monotonically increasing NuGet versions
- Makes newly merged changes quickly installable with dotnet tool update -g Nupeek

## Validation
- local tests pass
- workflow is self-contained and uses existing NUGET_API_KEY secret

Closes #57