### PR TITLE
🧪 ci(release): add NUGET_API_KEY preflight check

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,6 +55,15 @@ jobs:
             --output ./artifacts \
             /p:Version=${{ steps.version.outputs.package_version }}
 
+
+      - name: Validate NuGet API key
+        env:
+          NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
+        run: |
+          if [ -z "$NUGET_API_KEY" ]; then
+            echo "NUGET_API_KEY is not configured. Add it in repo Settings → Secrets and variables → Actions."
+            exit 1
+          fi
       - name: Publish to NuGet
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
## Summary
Add an explicit preflight check in release workflow so missing NuGet secret fails early with a clear message.

## What changed
- Added  step before publish
- Workflow now exits with actionable guidance if  is missing

## Why
- Prevents confusing late-stage 401 errors during publish
- Makes repo setup issues obvious and faster to fix

Closes #59