### PR TITLE
✨ feat(cli): add spinner progress UX with --progress option

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ So agents can reason from actual implementation details instead of guesswork.
 ```bash
 nupeek type --package Azure.Messaging.ServiceBus \
   --type Azure.Messaging.ServiceBus.ServiceBusSender \
-  --out deps-src --dry-run false
+  --out deps-src --dry-run false --progress auto
 
 # machine-readable contract for agents/tools
 nupeek type --package Polly --type Polly.Policy --out deps-src --format json

--- a/docs/README_DEEP.md
+++ b/docs/README_DEEP.md
@@ -11,8 +11,8 @@ Without source visibility, agents often infer behavior from signatures/docs only
 ## Core commands
 
 ```bash
-nupeek type --package <id> [--version <v>] [--tfm <tfm>] --type "<Namespace.Type>" --out deps-src [--format text|json]
-nupeek find --package <id> [--version <v>] [--tfm <tfm>] --symbol "<Namespace.Type.Method>" --out deps-src [--format text|json]
+nupeek type --package <id> [--version <v>] [--tfm <tfm>] --type "<Namespace.Type>" --out deps-src [--format text|json] [--progress auto|always|never]
+nupeek find --package <id> [--version <v>] [--tfm <tfm>] --symbol "<Namespace.Type.Method>" --out deps-src [--format text|json] [--progress auto|always|never]
 ```
 
 ## Typical output layout

--- a/tests/Nupeek.Cli.Tests/CliAppTests.cs
+++ b/tests/Nupeek.Cli.Tests/CliAppTests.cs
@@ -128,6 +128,26 @@ public class CliAppTests
     }
 
     [Fact]
+    public async Task RunAsync_InvalidProgressValue_ReturnsGenericError()
+    {
+        // Arrange
+        var args = new[]
+        {
+            "type",
+            "--package", "Polly",
+            "--type", "Polly.Policy",
+            "--out", "deps-src",
+            "--progress", "fast",
+        };
+
+        // Act
+        var code = await CliApp.RunAsync(args);
+
+        // Assert
+        Assert.Equal(ExitCodes.GenericError, code);
+    }
+
+    [Fact]
     public void BuildPlanText_IncludesSymbolWhenProvided()
     {
         // Arrange


### PR DESCRIPTION
## Summary
Add interactive CLI spinner UX so users can see Nupeek is actively executing during longer runs.

## What changed
- Added `--progress auto|always|never` option (default: `auto`)
- Spinner now appears during real execution in text mode
- Spinner is suppressed for:
  - `--format json`
  - `--quiet`
  - `--verbose` (verbose logs remain clean)
  - non-interactive contexts when progress is `auto`
- Spinner completion line includes elapsed time
- Updated docs/examples to include the progress option
- Added test coverage for invalid `--progress` value handling

## UX behavior
- Default (`auto`): interactive terminal gets spinner
- `always`: force spinner output
- `never`: disable spinner entirely

## Validation
- pre-commit passed
- dotnet test passed
- manual run confirmed spinner + elapsed completion output

Closes #61