### PR TITLE
♻️ refactor(cli): async execution path end-to-end

### DIFF
--- a/src/Nupeek.Cli/Features/Find/FindCommandFactory.cs
+++ b/src/Nupeek.Cli/Features/Find/FindCommandFactory.cs
@@ -6,7 +6,7 @@ namespace Nupeek.Cli;
 
 internal static class FindCommandFactory
 {
-    public static Command Create(GlobalCliOptions globalOptions, Func<PlanRequest, int> runPlan)
+    public static Command Create(GlobalCliOptions globalOptions, Func<PlanRequest, Task<int>> runPlanAsync)
     {
         var packageOption = new Option<string>("--package", "NuGet package id") { IsRequired = true };
         packageOption.AddAlias("-p");
@@ -29,11 +29,11 @@ internal static class FindCommandFactory
         command.AddOption(emitOption);
         command.AddOption(maxCharsOption);
 
-        command.SetHandler((InvocationContext context) =>
+        command.SetHandler(async (InvocationContext context) =>
         {
             var parse = context.ParseResult;
             var symbol = parse.GetValueForOption(symbolOption)!;
-            Environment.ExitCode = runPlan(new PlanRequest(
+            Environment.ExitCode = await runPlanAsync(new PlanRequest(
                 Command: "find",
                 Package: parse.GetValueForOption(packageOption)!,
                 Version: parse.GetValueForOption(versionOption) ?? "latest",
@@ -47,7 +47,7 @@ internal static class FindCommandFactory
                 Emit: parse.GetValueForOption(emitOption) ?? "files",
                 MaxChars: parse.GetValueForOption(maxCharsOption),
                 Progress: parse.GetValueForOption(globalOptions.Progress) ?? "auto",
-                SourceSymbol: symbol));
+                SourceSymbol: symbol)).ConfigureAwait(false);
         });
 
         return command;

--- a/src/Nupeek.Cli/Features/Type/TypeCommandFactory.cs
+++ b/src/Nupeek.Cli/Features/Type/TypeCommandFactory.cs
@@ -5,7 +5,7 @@ namespace Nupeek.Cli;
 
 internal static class TypeCommandFactory
 {
-    public static Command Create(GlobalCliOptions globalOptions, Func<PlanRequest, int> runPlan)
+    public static Command Create(GlobalCliOptions globalOptions, Func<PlanRequest, Task<int>> runPlanAsync)
     {
         var packageOption = new Option<string>("--package", "NuGet package id") { IsRequired = true };
         packageOption.AddAlias("-p");
@@ -28,10 +28,10 @@ internal static class TypeCommandFactory
         command.AddOption(emitOption);
         command.AddOption(maxCharsOption);
 
-        command.SetHandler((InvocationContext context) =>
+        command.SetHandler(async (InvocationContext context) =>
         {
             var parse = context.ParseResult;
-            Environment.ExitCode = runPlan(new PlanRequest(
+            Environment.ExitCode = await runPlanAsync(new PlanRequest(
                 Command: "type",
                 Package: parse.GetValueForOption(packageOption)!,
                 Version: parse.GetValueForOption(versionOption) ?? "latest",
@@ -45,7 +45,7 @@ internal static class TypeCommandFactory
                 Emit: parse.GetValueForOption(emitOption) ?? "files",
                 MaxChars: parse.GetValueForOption(maxCharsOption),
                 Progress: parse.GetValueForOption(globalOptions.Progress) ?? "auto",
-                SourceSymbol: null));
+                SourceSymbol: null)).ConfigureAwait(false);
         });
 
         return command;


### PR DESCRIPTION
## Summary
Implements issue #73 by removing sync-over-async from CLI execution flow and making command execution async end-to-end.

## What changed
- RunPlan -> RunPlanAsync
- ExecutePlan -> ExecutePlanAsync
- HandleRealRun -> HandleRealRunAsync
- ExecuteWithSpinner -> async variant
- type/find command factories now accept and await async plan executor delegates
- Removed blocking GetAwaiter().GetResult() for pipeline call path in CLI

## Behavior
- CLI options/help/output/exit codes are preserved
- No intended user-facing behavior changes

## Validation
- pre-commit passed
- dotnet test passed

Closes #73
