### PR TITLE
✨ feat(cli): propagate cancellation and handle Ctrl+C

### DIFF
--- a/src/Nupeek.Cli/ExitCodes.cs
+++ b/src/Nupeek.Cli/ExitCodes.cs
@@ -22,4 +22,7 @@ public static class ExitCodes
 
     /// <summary>Failure while decompiling or writing generated output.</summary>
     public const int DecompilationFailure = 5;
+
+    /// <summary>Operation canceled by user (Ctrl+C).</summary>
+    public const int OperationCanceled = 130;
 }


### PR DESCRIPTION
## Summary
Implements issue #74 by adding cancellation token propagation from CLI to pipeline and handling Ctrl+C gracefully.

## What changed
- Added CLI cancellation source in 
- Hooked  to trigger cancellation instead of abrupt process termination
- Propagated  through CLI execution path into pipeline call
- Added explicit cancellation outcome mapping in real-run path
- Added stable cancel exit code: 

## Behavior
- Ctrl+C now requests graceful cancellation
- Spinner/output cleanup path remains intact
- Existing output contracts remain unchanged except deterministic cancel message/exit code

## Validation
- pre-commit passed
- dotnet test passed

Closes #74