### PR TITLE
♻️ refactor(core): migrate file I/O paths to async APIs

### DIFF
--- a/src/Nupeek.Cli/CliApp.cs
+++ b/src/Nupeek.Cli/CliApp.cs
@@ -220,7 +220,7 @@ public static class CliApp
                 request.Type,
                 request.OutDir), cancellationToken).ConfigureAwait(false);
 
-            var inlineSource = InlineSourceReader.ReadInlineSource(result.OutputPath, emit, maxChars);
+            var inlineSource = await InlineSourceReader.ReadInlineSourceAsync(result.OutputPath, emit, maxChars, cancellationToken).ConfigureAwait(false);
 
             return new CliOutcome(
                 ExitCodes.Success,

--- a/src/Nupeek.Cli/Internal/InlineSourceReader.cs
+++ b/src/Nupeek.Cli/Internal/InlineSourceReader.cs
@@ -3,13 +3,16 @@ namespace Nupeek.Cli;
 internal static class InlineSourceReader
 {
     public static InlineSourceResult ReadInlineSource(string outputPath, string emit, int maxChars)
+        => ReadInlineSourceAsync(outputPath, emit, maxChars).GetAwaiter().GetResult();
+
+    public static async Task<InlineSourceResult> ReadInlineSourceAsync(string outputPath, string emit, int maxChars, CancellationToken cancellationToken = default)
     {
         if (!string.Equals(emit, "agent", StringComparison.Ordinal) || !File.Exists(outputPath))
         {
             return new InlineSourceResult(null, null, null, false);
         }
 
-        var source = File.ReadAllText(outputPath);
+        var source = await File.ReadAllTextAsync(outputPath, cancellationToken).ConfigureAwait(false);
         var originalChars = source.Length;
         var truncated = source.Length > maxChars;
 

--- a/src/Nupeek.Core/TypeDecompilePipeline.cs
+++ b/src/Nupeek.Core/TypeDecompilePipeline.cs
@@ -65,18 +65,18 @@ public sealed class TypeDecompilePipeline
             request.TypeName);
 
         // 4) Decompile target type into generated C# file.
-        _decompiler.DecompileType(content.AssemblyPath, request.TypeName, outputPath);
+        await _decompiler.DecompileTypeAsync(content.AssemblyPath, request.TypeName, outputPath, cancellationToken).ConfigureAwait(false);
 
         // 5) Update index and manifest for downstream tooling.
-        var indexPath = _catalogWriter.WriteIndex(request.OutputRoot, request.TypeName, outputPath);
-        var manifestPath = _catalogWriter.WriteManifest(request.OutputRoot, new ManifestEntry(
+        var indexPath = await _catalogWriter.WriteIndexAsync(request.OutputRoot, request.TypeName, outputPath, cancellationToken).ConfigureAwait(false);
+        var manifestPath = await _catalogWriter.WriteManifestAsync(request.OutputRoot, new ManifestEntry(
             package.PackageId,
             package.Version,
             content.SelectedTfm,
             request.TypeName,
             content.AssemblyPath,
             outputPath,
-            DateTimeOffset.UtcNow));
+            DateTimeOffset.UtcNow), cancellationToken).ConfigureAwait(false);
 
         return new TypeDecompileResult(
             package.PackageId,

--- a/src/Nupeek.Core/TypeDecompiler.cs
+++ b/src/Nupeek.Core/TypeDecompiler.cs
@@ -13,6 +13,12 @@ public sealed class TypeDecompiler
     /// Decompiles the requested type and writes the generated source to disk.
     /// </summary>
     public void DecompileType(string assemblyPath, string fullTypeName, string outputPath)
+        => DecompileTypeAsync(assemblyPath, fullTypeName, outputPath).GetAwaiter().GetResult();
+
+    /// <summary>
+    /// Decompiles the requested type and writes the generated source to disk (async write).
+    /// </summary>
+    public async Task DecompileTypeAsync(string assemblyPath, string fullTypeName, string outputPath, CancellationToken cancellationToken = default)
     {
         ArgumentException.ThrowIfNullOrWhiteSpace(assemblyPath);
         ArgumentException.ThrowIfNullOrWhiteSpace(fullTypeName);
@@ -35,6 +41,6 @@ public sealed class TypeDecompiler
             ?? throw new InvalidOperationException("Output path directory is missing.");
 
         Directory.CreateDirectory(directory);
-        File.WriteAllText(outputPath, syntax.ToString());
+        await File.WriteAllTextAsync(outputPath, syntax.ToString(), cancellationToken).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary
Implements issue #75 by migrating key file I/O paths to async APIs and wiring them into the async execution flow.

## What changed
- 
  - added , , and async JSON read path
- 
  - added  with async file write
- 
  - now awaits async decompile/catalog write methods
- 
  - added  with async file read
- 
  - now awaits 

## Notes
- Existing sync methods are retained as wrappers for compatibility where still needed
- Output format/behavior contracts unchanged

## Validation
- pre-commit passed
- dotnet test passed

Closes #75