### PR TITLE
✨ feat(cli): improve root help discoverability and examples

### DIFF
--- a/src/Nupeek.Cli/CliApp.cs
+++ b/src/Nupeek.Cli/CliApp.cs
@@ -95,9 +95,17 @@ public static class CliApp
         var globalOptions = new GlobalCliOptions(verboseOption, quietOption, dryRunOption, progressOption);
 
         root.Description += Environment.NewLine + Environment.NewLine +
+            "Command options:" + Environment.NewLine +
+            "  type: --package|-p --type --out [--version] [--tfm] [--format text|json] [--emit files|agent] [--max-chars N]" + Environment.NewLine +
+            "  find: --package|-p --symbol --out [--version] [--tfm] [--format text|json] [--emit files|agent] [--max-chars N]" + Environment.NewLine + Environment.NewLine +
+            "Tip:" + Environment.NewLine +
+            "  Run 'nupeek <command> --help' to see full per-command options." + Environment.NewLine + Environment.NewLine +
             "Examples:" + Environment.NewLine +
             "  nupeek type --package Azure.Messaging.ServiceBus --type Azure.Messaging.ServiceBus.ServiceBusSender --out deps-src" + Environment.NewLine +
-            "  nupeek find --package Polly --symbol Polly.Policy.Handle --out deps-src";
+            "  nupeek type --package Humanizer.Core --version 2.14.1 --tfm netstandard2.0 --type Humanizer.StringHumanizeExtensions --out deps-src --dry-run false" + Environment.NewLine +
+            "  nupeek type --package Polly --type Polly.Policy --out deps-src --format json --emit agent --max-chars 4000 --dry-run false" + Environment.NewLine +
+            "  nupeek find --package Polly --symbol Polly.Policy.Handle --out deps-src" + Environment.NewLine +
+            "  nupeek find --package Dapper --symbol Dapper.SqlMapper.Query --out deps-src --progress never --dry-run false";
 
         root.AddCommand(TypeCommandFactory.Create(globalOptions, request => RunPlanHandler.RunAsync(request, cancellationToken)));
         root.AddCommand(FindCommandFactory.Create(globalOptions, request => RunPlanHandler.RunAsync(request, cancellationToken)));


### PR DESCRIPTION
## What changed
- Expanded `nupeek --help` description with a concise command option summary for `type` and `find`.
- Added an explicit tip to use `nupeek <command> --help` for full per-command options.
- Added richer real-world examples covering:
  - explicit `--version` and `--tfm`
  - JSON output (`--format json`)
  - inline emit mode (`--emit agent`, `--max-chars`)
  - progress control (`--progress never`)
  - real execution (`--dry-run false`)

## Validation
- `dotnet run --project src/Nupeek.Cli -- --help`
- `dotnet run --project src/Nupeek.Cli -- type --help`
- `dotnet test`

Closes #84
