### PR TITLE
✨ feat(web): host installer at nupeek.dev/install.sh

### DIFF
--- a/docs/INSTALL.md
+++ b/docs/INSTALL.md
@@ -19,13 +19,13 @@ dotnet tool install -g Nupeek
 ### One-line installer (curl | sh)
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ghostmxvlshn/nupeek/main/install.sh | bash
+curl -fsSL https://nupeek.dev/install.sh | bash
 ```
 
 Pin a version:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/ghostmxvlshn/nupeek/main/install.sh | VERSION=0.1.0 bash
+curl -fsSL https://nupeek.dev/install.sh | VERSION=0.1.0 bash
 ```
 
 Update later:

--- a/web/CNAME
+++ b/web/CNAME
@@ -1,0 +1,1 @@
+nupeek.dev

--- a/web/index.html
+++ b/web/index.html
@@ -98,7 +98,7 @@ nupeek --help</code></pre>
                   <span>bash</span>
                   <button class="copy-btn" data-copy-target="install-curl-pipe">Copy</button>
                 </div>
-                <pre><code id="install-curl-pipe">curl -fsSL https://raw.githubusercontent.com/ghostmxvlshn/nupeek/main/install.sh | bash</code></pre>
+                <pre><code id="install-curl-pipe">curl -fsSL https://nupeek.dev/install.sh | bash</code></pre>
               </div>
             </article>
           </div>

--- a/web/install.sh
+++ b/web/install.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PACKAGE_ID="Nupeek"
+VERSION="${VERSION:-}"
+TOOLS_PATH="${TOOLS_PATH:-$HOME/.dotnet/tools}"
+
+has_cmd() {
+  command -v "$1" >/dev/null 2>&1
+}
+
+log() {
+  printf '[nupeek-install] %s\n' "$*"
+}
+
+if ! has_cmd dotnet; then
+  log "dotnet SDK is required but was not found in PATH."
+  log "Install .NET SDK 10+ first: https://dotnet.microsoft.com/download"
+  exit 1
+fi
+
+if dotnet tool list -g | awk 'NR>2 {print $1}' | grep -qi '^nupeek$'; then
+  if [[ -n "$VERSION" ]]; then
+    log "Updating $PACKAGE_ID to version $VERSION"
+    dotnet tool update -g "$PACKAGE_ID" --version "$VERSION"
+  else
+    log "Updating $PACKAGE_ID to latest"
+    dotnet tool update -g "$PACKAGE_ID"
+  fi
+else
+  if [[ -n "$VERSION" ]]; then
+    log "Installing $PACKAGE_ID version $VERSION"
+    dotnet tool install -g "$PACKAGE_ID" --version "$VERSION"
+  else
+    log "Installing $PACKAGE_ID latest"
+    dotnet tool install -g "$PACKAGE_ID"
+  fi
+fi
+
+if [[ ":$PATH:" != *":$TOOLS_PATH:"* ]]; then
+  log "Nupeek installed, but $TOOLS_PATH is not currently in PATH."
+  log "Add this to your shell profile:"
+  log "  export PATH=\"\$PATH:$TOOLS_PATH\""
+else
+  log "PATH already contains $TOOLS_PATH"
+fi
+
+if has_cmd nupeek; then
+  log "Install complete."
+  nupeek --help >/dev/null
+  log "Verified: nupeek --help"
+else
+  log "Nupeek command not visible in current shell yet. Open a new shell or update PATH."
+fi


### PR DESCRIPTION
## What changed
- Added `web/install.sh` so the installer is served from the landing domain path.
- Added `web/CNAME` with `nupeek.dev` for GitHub Pages custom domain.
- Updated landing page install command to use:
  - `curl -fsSL https://nupeek.dev/install.sh | bash`
- Updated `docs/INSTALL.md` curl examples to use `https://nupeek.dev/install.sh`.

## Why
This matches the Tally-style installer UX where users copy a clean domain URL instead of a long raw GitHub URL.

## Notes
After deploy + DNS propagation, verify:
- `curl -I https://nupeek.dev/install.sh`
- `curl -fsSL https://nupeek.dev/install.sh | head -n 5`

Closes #88
