### PR TITLE
✨ feat(cli): support --assembly source mode for direct DLL decompilation

### DIFF
--- a/.github/skills/nupeek/SKILL.md
+++ b/.github/skills/nupeek/SKILL.md
@@ -24,7 +24,9 @@ Skip this skill when:
 
 ## Workflow
 
-1. Resolve package name + version from project files/lock data.
+1. Resolve source input. Prefer **assembly mode** when possible (this is usually best in real projects):
+   - if the dependency DLL already exists in `bin/`, `obj/`, `.nuget/packages`, or project artifacts, use `--assembly`
+   - fall back to `--package` only when assembly path is unavailable
 
 2. If the user asks about a **method implementation**, inspect local code usage first:
    - find where the method is called in the current codebase
@@ -36,22 +38,30 @@ Skip this skill when:
 rg -n "WaitAndRetry\(" .
 ```
 
-3. Run Nupeek for the exact type first (narrow scope):
+3. Run Nupeek for the exact type first (narrow scope), preferring assembly input:
 
 ```bash
+# Preferred in ~99% of real tasks (assembly already present locally)
+nupeek type --assembly <path-to.dll> --type <Namespace.Type> --out deps-src
+
+# Fallback when assembly path is not available
 nupeek type --package <PackageId> --type <Namespace.Type> --out deps-src
 ```
 
 4. If the type is unknown, discover candidates from member/type symbol:
 
 ```bash
+# Preferred
+nupeek find --assembly <path-to.dll> --symbol <Namespace.TypeOrMember> --out deps-src
+
+# Fallback
 nupeek find --package <PackageId> --symbol <Namespace.TypeOrMember> --out deps-src
 ```
 
 5. If `find` returns multiple candidates for a member, choose one declaring type and rerun `type`:
 
 ```bash
-nupeek type --package <PackageId> --type <Resolved.Namespace.Type> --out deps-src
+nupeek type --assembly <path-to.dll> --type <Resolved.Namespace.Type> --out deps-src
 ```
 
 6. Choose output mode based on task:
@@ -85,6 +95,8 @@ When using Nupeek, report:
 
 ## CLI Options to Use Intentionally
 
+- `--assembly <path-to.dll>` → preferred source when dependency assembly already exists locally
+- `--package <id>` (+ optional `--version`) → fallback source when assembly path is unavailable
 - `--format text|json` → human vs machine-readable output
 - `--emit files|agent` → files-first vs inline agent payload
 - `--max-chars <n>` → inline source cap for `--emit agent`

--- a/src/Nupeek.Cli/CliApp.cs
+++ b/src/Nupeek.Cli/CliApp.cs
@@ -96,8 +96,8 @@ public static class CliApp
 
         root.Description += Environment.NewLine + Environment.NewLine +
             "Command options:" + Environment.NewLine +
-            "  type: --package|-p --type --out [--version] [--tfm] [--format text|json] [--emit files|agent] [--max-chars N]" + Environment.NewLine +
-            "  find: --package|-p --symbol --out [--version] [--tfm] [--format text|json] [--emit files|agent] [--max-chars N]" + Environment.NewLine + Environment.NewLine +
+            "  type: (--package|-p <id> | --assembly <dll>) --type --out [--version] [--tfm] [--format text|json] [--emit files|agent] [--max-chars N]" + Environment.NewLine +
+            "  find: (--package|-p <id> | --assembly <dll>) --symbol --out [--version] [--tfm] [--format text|json] [--emit files|agent] [--max-chars N]" + Environment.NewLine + Environment.NewLine +
             "Tip:" + Environment.NewLine +
             "  Run 'nupeek <command> --help' to see full per-command options." + Environment.NewLine + Environment.NewLine +
             "Examples:" + Environment.NewLine +
@@ -105,7 +105,8 @@ public static class CliApp
             "  nupeek type --package Humanizer.Core --version 2.14.1 --tfm netstandard2.0 --type Humanizer.StringHumanizeExtensions --out deps-src --dry-run false" + Environment.NewLine +
             "  nupeek type --package Polly --type Polly.Policy --out deps-src --format json --emit agent --max-chars 4000 --dry-run false" + Environment.NewLine +
             "  nupeek find --package Polly --symbol Polly.Policy.Handle --out deps-src" + Environment.NewLine +
-            "  nupeek find --package Dapper --symbol Dapper.SqlMapper.Query --out deps-src --progress never --dry-run false";
+            "  nupeek find --package Dapper --symbol Dapper.SqlMapper.Query --out deps-src --progress never" + Environment.NewLine +
+            "  nupeek type --assembly ./bin/Debug/net8.0/MyApp.Services.dll --type MyApp.Services.RetryHelper --out deps-src";
 
         root.AddCommand(TypeCommandFactory.Create(globalOptions, request => RunPlanHandler.RunAsync(request, cancellationToken)));
         root.AddCommand(FindCommandFactory.Create(globalOptions, request => RunPlanHandler.RunAsync(request, cancellationToken)));

--- a/src/Nupeek.Cli/Contracts/PlanRequest.cs
+++ b/src/Nupeek.Cli/Contracts/PlanRequest.cs
@@ -2,7 +2,8 @@ namespace Nupeek.Cli;
 
 internal sealed record PlanRequest(
     string Command,
-    string Package,
+    string? Package,
+    string? Assembly,
     string Version,
     string Tfm,
     string Type,

--- a/src/Nupeek.Cli/Features/Find/FindCommandFactory.cs
+++ b/src/Nupeek.Cli/Features/Find/FindCommandFactory.cs
@@ -8,10 +8,11 @@ internal static class FindCommandFactory
 {
     public static Command Create(GlobalCliOptions globalOptions, Func<PlanRequest, Task<int>> runPlanAsync)
     {
-        var packageOption = new Option<string>("--package", "NuGet package id") { IsRequired = true };
+        var packageOption = new Option<string?>("--package", "NuGet package id.");
         packageOption.AddAlias("-p");
 
-        var versionOption = new Option<string?>("--version", "NuGet package version. Defaults to latest.");
+        var assemblyOption = new Option<string?>("--assembly", "Path to local assembly (.dll). Prefer this when dependency is already restored.");
+        var versionOption = new Option<string?>("--version", "NuGet package version. Defaults to latest. Ignored with --assembly.");
         var tfmOption = new Option<string?>("--tfm", "Target framework moniker. Defaults to auto.");
         var symbolOption = new Option<string>("--symbol", "Symbol name, e.g. Namespace.Type.Method") { IsRequired = true };
         var outOption = new Option<string>("--out", "Output directory (e.g. deps-src)") { IsRequired = true };
@@ -21,6 +22,7 @@ internal static class FindCommandFactory
 
         var command = new Command("find", "Resolve symbol to type and decompile that type.");
         command.AddOption(packageOption);
+        command.AddOption(assemblyOption);
         command.AddOption(versionOption);
         command.AddOption(tfmOption);
         command.AddOption(symbolOption);
@@ -32,10 +34,22 @@ internal static class FindCommandFactory
         command.SetHandler(async (InvocationContext context) =>
         {
             var parse = context.ParseResult;
+            var package = parse.GetValueForOption(packageOption);
+            var assembly = parse.GetValueForOption(assemblyOption);
+
+            var validation = ValidateSource(package, assembly);
+            if (validation is not null)
+            {
+                Console.Error.WriteLine(validation);
+                Environment.ExitCode = ExitCodes.InvalidArguments;
+                return;
+            }
+
             var symbol = parse.GetValueForOption(symbolOption)!;
             Environment.ExitCode = await runPlanAsync(new PlanRequest(
                 Command: "find",
-                Package: parse.GetValueForOption(packageOption)!,
+                Package: package,
+                Assembly: assembly,
                 Version: parse.GetValueForOption(versionOption) ?? "latest",
                 Tfm: parse.GetValueForOption(tfmOption) ?? "auto",
                 Type: SymbolParser.ToTypeName(symbol),
@@ -51,5 +65,20 @@ internal static class FindCommandFactory
         });
 
         return command;
+    }
+
+    private static string? ValidateSource(string? package, string? assembly)
+    {
+        if (string.IsNullOrWhiteSpace(package) && string.IsNullOrWhiteSpace(assembly))
+        {
+            return "Provide exactly one source: --package <id> or --assembly <path-to-dll>.";
+        }
+
+        if (!string.IsNullOrWhiteSpace(package) && !string.IsNullOrWhiteSpace(assembly))
+        {
+            return "Use either --package or --assembly, not both.";
+        }
+
+        return null;
     }
 }

--- a/src/Nupeek.Cli/Features/RunPlan/RunPlanDryRunOutcomeFactory.cs
+++ b/src/Nupeek.Cli/Features/RunPlan/RunPlanDryRunOutcomeFactory.cs
@@ -6,7 +6,7 @@ internal static class RunPlanDryRunOutcomeFactory
         => new(
             ExitCodes.Success,
             null,
-            request.Package,
+            RunPlanSourceLabel.Get(request),
             request.Version,
             request.Tfm,
             null,

--- a/src/Nupeek.Cli/Features/RunPlan/RunPlanOutcomeEmitter.cs
+++ b/src/Nupeek.Cli/Features/RunPlan/RunPlanOutcomeEmitter.cs
@@ -65,7 +65,7 @@ internal static class RunPlanOutcomeEmitter
     {
         Console.WriteLine(RunPlanTextBuilder.Build(
             request.Command,
-            request.Package,
+RunPlanSourceLabel.Get(request),
             request.Version,
             request.Tfm,
             request.Type,

--- a/src/Nupeek.Cli/Features/RunPlan/RunPlanRealExecution.cs
+++ b/src/Nupeek.Cli/Features/RunPlan/RunPlanRealExecution.cs
@@ -13,6 +13,7 @@ internal static class RunPlanRealExecution
             var pipeline = new TypeDecompilePipeline();
             var result = await pipeline.RunAsync(new TypeDecompileRequest(
                 request.Package,
+                request.Assembly,
                 string.Equals(request.Version, "latest", StringComparison.OrdinalIgnoreCase) ? null : request.Version,
                 string.Equals(request.Tfm, "auto", StringComparison.OrdinalIgnoreCase) ? null : request.Tfm,
                 normalizedType,
@@ -39,19 +40,19 @@ internal static class RunPlanRealExecution
         }
         catch (OperationCanceledException)
         {
-            return new CliOutcome(ExitCodes.OperationCanceled, "Operation canceled.", request.Package, request.Version, request.Tfm, null, null, null, null, null, null, null, false);
+            return new CliOutcome(ExitCodes.OperationCanceled, "Operation canceled.", RunPlanSourceLabel.Get(request), request.Version, request.Tfm, null, null, null, null, null, null, null, false);
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("not found", StringComparison.OrdinalIgnoreCase))
         {
-            return new CliOutcome(ExitCodes.TypeOrSymbolNotFound, ex.Message, request.Package, request.Version, request.Tfm, null, null, null, null, null, null, null, false);
+            return new CliOutcome(ExitCodes.TypeOrSymbolNotFound, ex.Message, RunPlanSourceLabel.Get(request), request.Version, request.Tfm, null, null, null, null, null, null, null, false);
         }
         catch (InvalidOperationException ex)
         {
-            return new CliOutcome(ExitCodes.PackageResolutionFailure, ex.Message, request.Package, request.Version, request.Tfm, null, null, null, null, null, null, null, false);
+            return new CliOutcome(ExitCodes.PackageResolutionFailure, ex.Message, RunPlanSourceLabel.Get(request), request.Version, request.Tfm, null, null, null, null, null, null, null, false);
         }
         catch (Exception ex)
         {
-            return new CliOutcome(ExitCodes.DecompilationFailure, $"Decompilation failed: {ex.Message}", request.Package, request.Version, request.Tfm, null, null, null, null, null, null, null, false);
+            return new CliOutcome(ExitCodes.DecompilationFailure, $"Decompilation failed: {ex.Message}", RunPlanSourceLabel.Get(request), request.Version, request.Tfm, null, null, null, null, null, null, null, false);
         }
     }
 }

--- a/src/Nupeek.Cli/Features/RunPlan/RunPlanSourceLabel.cs
+++ b/src/Nupeek.Cli/Features/RunPlan/RunPlanSourceLabel.cs
@@ -1,0 +1,9 @@
+namespace Nupeek.Cli;
+
+internal static class RunPlanSourceLabel
+{
+    public static string Get(PlanRequest request)
+        => !string.IsNullOrWhiteSpace(request.Package)
+            ? request.Package!
+            : request.Assembly ?? "assembly";
+}

--- a/src/Nupeek.Cli/Features/Type/TypeCommandFactory.cs
+++ b/src/Nupeek.Cli/Features/Type/TypeCommandFactory.cs
@@ -7,10 +7,11 @@ internal static class TypeCommandFactory
 {
     public static Command Create(GlobalCliOptions globalOptions, Func<PlanRequest, Task<int>> runPlanAsync)
     {
-        var packageOption = new Option<string>("--package", "NuGet package id") { IsRequired = true };
+        var packageOption = new Option<string?>("--package", "NuGet package id.");
         packageOption.AddAlias("-p");
 
-        var versionOption = new Option<string?>("--version", "NuGet package version. Defaults to latest.");
+        var assemblyOption = new Option<string?>("--assembly", "Path to local assembly (.dll). Prefer this when dependency is already restored.");
+        var versionOption = new Option<string?>("--version", "NuGet package version. Defaults to latest. Ignored with --assembly.");
         var tfmOption = new Option<string?>("--tfm", "Target framework moniker. Defaults to auto.");
         var typeOption = new Option<string>("--type", "Fully-qualified type name (e.g. Namespace.Type)") { IsRequired = true };
         var outOption = new Option<string>("--out", "Output directory (e.g. deps-src)") { IsRequired = true };
@@ -18,8 +19,9 @@ internal static class TypeCommandFactory
         var emitOption = new Option<string>("--emit", () => "files", "Emit mode: files (default) or agent.");
         var maxCharsOption = new Option<int>("--max-chars", () => 12000, "Max inline source chars for --emit agent.");
 
-        var command = new Command("type", "Decompile a single type from a NuGet package.");
+        var command = new Command("type", "Decompile a single type from a NuGet package or local assembly.");
         command.AddOption(packageOption);
+        command.AddOption(assemblyOption);
         command.AddOption(versionOption);
         command.AddOption(tfmOption);
         command.AddOption(typeOption);
@@ -31,9 +33,21 @@ internal static class TypeCommandFactory
         command.SetHandler(async (InvocationContext context) =>
         {
             var parse = context.ParseResult;
+            var package = parse.GetValueForOption(packageOption);
+            var assembly = parse.GetValueForOption(assemblyOption);
+
+            var validation = ValidateSource(package, assembly);
+            if (validation is not null)
+            {
+                Console.Error.WriteLine(validation);
+                Environment.ExitCode = ExitCodes.InvalidArguments;
+                return;
+            }
+
             Environment.ExitCode = await runPlanAsync(new PlanRequest(
                 Command: "type",
-                Package: parse.GetValueForOption(packageOption)!,
+                Package: package,
+                Assembly: assembly,
                 Version: parse.GetValueForOption(versionOption) ?? "latest",
                 Tfm: parse.GetValueForOption(tfmOption) ?? "auto",
                 Type: parse.GetValueForOption(typeOption)!,
@@ -49,5 +63,20 @@ internal static class TypeCommandFactory
         });
 
         return command;
+    }
+
+    private static string? ValidateSource(string? package, string? assembly)
+    {
+        if (string.IsNullOrWhiteSpace(package) && string.IsNullOrWhiteSpace(assembly))
+        {
+            return "Provide exactly one source: --package <id> or --assembly <path-to-dll>.";
+        }
+
+        if (!string.IsNullOrWhiteSpace(package) && !string.IsNullOrWhiteSpace(assembly))
+        {
+            return "Use either --package or --assembly, not both.";
+        }
+
+        return null;
     }
 }

--- a/src/Nupeek.Core/Features/DecompileType/Contracts/TypeDecompileRequest.cs
+++ b/src/Nupeek.Core/Features/DecompileType/Contracts/TypeDecompileRequest.cs
@@ -3,13 +3,15 @@ namespace Nupeek.Core;
 /// <summary>
 /// Input contract for end-to-end decompilation of a single type.
 /// </summary>
-/// <param name="PackageId">NuGet package id.</param>
+/// <param name="PackageId">NuGet package id. Optional when <paramref name="AssemblyPath"/> is provided.</param>
+/// <param name="AssemblyPath">Optional path to a local assembly (.dll) to decompile directly.</param>
 /// <param name="Version">Optional package version. If null, latest stable is used.</param>
 /// <param name="Tfm">Optional target framework. If null, best available is selected.</param>
 /// <param name="TypeName">Fully-qualified target type name to decompile.</param>
 /// <param name="OutputRoot">Output root for generated source and catalogs.</param>
 public sealed record TypeDecompileRequest(
-    string PackageId,
+    string? PackageId,
+    string? AssemblyPath,
     string? Version,
     string? Tfm,
     string TypeName,

--- a/src/Nupeek.Core/Features/DecompileType/TypeDecompilePipeline.cs
+++ b/src/Nupeek.Core/Features/DecompileType/TypeDecompilePipeline.cs
@@ -36,56 +36,73 @@ public sealed class TypeDecompilePipeline
     }
 
     /// <summary>
-    /// Executes package acquisition, type location, decompilation, and catalog updates.
+    /// Executes package acquisition (or local assembly mode), type location, decompilation, and catalog updates.
     /// </summary>
     public async Task<TypeDecompileResult> RunAsync(TypeDecompileRequest request, CancellationToken cancellationToken = default)
     {
-        ArgumentException.ThrowIfNullOrWhiteSpace(request.PackageId);
+        ValidateSource(request);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.TypeName);
         ArgumentException.ThrowIfNullOrWhiteSpace(request.OutputRoot);
 
-        // Keep package artifacts under output root so the run is self-contained.
-        var cacheRoot = Path.Combine(request.OutputRoot, ".cache");
+        var source = await ResolveSourceAsync(request, cancellationToken).ConfigureAwait(false);
+        var content = source.Content;
 
-        // 1) Acquire package and extracted content.
-        var package = await _acquirer.AcquireAsync(new NuGetPackageRequest(request.PackageId, request.Version, cacheRoot), cancellationToken).ConfigureAwait(false);
-
-        // 2) Resolve lib/TFM and assembly containing target type.
-        var content = _locator.Locate(new PackageContentRequest(
-            package.ExtractedPath,
-            request.TypeName,
-            request.Tfm));
-
-        // 3) Compute deterministic output file path.
         var outputPath = OutputPathBuilder.BuildTypeOutputPath(
             request.OutputRoot,
-            package.PackageId,
-            package.Version,
+            source.PackageId,
+            source.Version,
             content.SelectedTfm,
-            request.TypeName);
+            content.FullTypeName);
 
-        // 4) Decompile target type into generated C# file.
-        await _decompiler.DecompileTypeAsync(content.AssemblyPath, request.TypeName, outputPath, cancellationToken).ConfigureAwait(false);
+        await _decompiler.DecompileTypeAsync(content.AssemblyPath, content.FullTypeName, outputPath, cancellationToken).ConfigureAwait(false);
 
-        // 5) Update index and manifest for downstream tooling.
-        var indexPath = await _catalogWriter.WriteIndexAsync(request.OutputRoot, request.TypeName, outputPath, cancellationToken).ConfigureAwait(false);
+        var indexPath = await _catalogWriter.WriteIndexAsync(request.OutputRoot, content.FullTypeName, outputPath, cancellationToken).ConfigureAwait(false);
         var manifestPath = await _catalogWriter.WriteManifestAsync(request.OutputRoot, new ManifestEntry(
-            package.PackageId,
-            package.Version,
+            source.PackageId,
+            source.Version,
             content.SelectedTfm,
-            request.TypeName,
+            content.FullTypeName,
             content.AssemblyPath,
             outputPath,
             DateTimeOffset.UtcNow), cancellationToken).ConfigureAwait(false);
 
         return new TypeDecompileResult(
-            package.PackageId,
-            package.Version,
+            source.PackageId,
+            source.Version,
             content.SelectedTfm,
-            request.TypeName,
+            content.FullTypeName,
             content.AssemblyPath,
             outputPath,
             indexPath,
             manifestPath);
+    }
+
+    private static void ValidateSource(TypeDecompileRequest request)
+    {
+        var hasPackage = !string.IsNullOrWhiteSpace(request.PackageId);
+        var hasAssembly = !string.IsNullOrWhiteSpace(request.AssemblyPath);
+
+        if (hasPackage == hasAssembly)
+        {
+            throw new ArgumentException("Provide exactly one source: package or assembly path.", nameof(request));
+        }
+    }
+
+    private async Task<(string PackageId, string Version, PackageContentResult Content)> ResolveSourceAsync(TypeDecompileRequest request, CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(request.AssemblyPath))
+        {
+            var assemblyPath = request.AssemblyPath!.Trim();
+            var content = _locator.LocateInAssembly(assemblyPath, request.TypeName);
+
+            var packageId = Path.GetFileNameWithoutExtension(assemblyPath).ToLowerInvariant();
+            return (packageId, "local", content);
+        }
+
+        var cacheRoot = Path.Combine(request.OutputRoot, ".cache");
+        var package = await _acquirer.AcquireAsync(new NuGetPackageRequest(request.PackageId!, request.Version, cacheRoot), cancellationToken).ConfigureAwait(false);
+        var packageContent = _locator.Locate(new PackageContentRequest(package.ExtractedPath, request.TypeName, request.Tfm));
+
+        return (package.PackageId, package.Version, packageContent);
     }
 }

--- a/src/Nupeek.Core/Features/LocateType/PackageTypeLocator.cs
+++ b/src/Nupeek.Core/Features/LocateType/PackageTypeLocator.cs
@@ -9,6 +9,46 @@ namespace Nupeek.Core;
 public sealed class PackageTypeLocator
 {
     /// <summary>
+    /// Locates target type directly inside a specific assembly path.
+    /// </summary>
+    public PackageContentResult LocateInAssembly(string assemblyPath, string fullTypeName)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(assemblyPath);
+        ArgumentException.ThrowIfNullOrWhiteSpace(fullTypeName);
+
+        if (!File.Exists(assemblyPath))
+        {
+            throw new InvalidOperationException($"Assembly was not found: {assemblyPath}");
+        }
+
+        var normalizedType = TypeNameNormalizer.Normalize(fullTypeName);
+        var dir = Path.GetDirectoryName(Path.GetFullPath(assemblyPath)) ?? ".";
+
+        var exact = FindTypeInSingleAssembly(assemblyPath, normalizedType);
+        if (!string.IsNullOrWhiteSpace(exact))
+        {
+            return new PackageContentResult("assembly", dir, assemblyPath, exact);
+        }
+
+        var memberName = SymbolParser.ExtractMemberName(fullTypeName);
+        var memberTypes = FindDeclaringTypesForMemberNameInAssembly(assemblyPath, memberName);
+
+        if (memberTypes.Count == 1)
+        {
+            return new PackageContentResult("assembly", dir, assemblyPath, memberTypes[0]);
+        }
+
+        if (memberTypes.Count > 1)
+        {
+            var suggestions = string.Join(", ", memberTypes.OrderBy(static x => x, StringComparer.Ordinal).Take(5));
+            throw new InvalidOperationException(
+                $"Type '{normalizedType}' was not found in '{assemblyPath}'. Found member '{memberName}' in multiple types: {suggestions}. Use --type with a fully-qualified type name.");
+        }
+
+        throw new InvalidOperationException($"Type '{normalizedType}' was not found in '{assemblyPath}'.");
+    }
+
+    /// <summary>
     /// Locates package content (TFM/lib/assembly) for the requested type.
     /// </summary>
     public PackageContentResult Locate(PackageContentRequest request)
@@ -183,6 +223,70 @@ public sealed class PackageTypeLocator
         => typeDef.GetEvents()
             .Select(md.GetEventDefinition)
             .Any(eventDef => string.Equals(md.GetString(eventDef.Name), memberName, StringComparison.Ordinal));
+
+    private static string? FindTypeInSingleAssembly(string assemblyPath, string fullTypeName)
+    {
+        try
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            using var peReader = new PEReader(stream);
+
+            if (!peReader.HasMetadata)
+            {
+                return null;
+            }
+
+            var md = peReader.GetMetadataReader();
+            foreach (var handle in md.TypeDefinitions)
+            {
+                var typeName = GetTypeFullName(md, handle);
+                if (string.Equals(typeName, fullTypeName, StringComparison.Ordinal))
+                {
+                    return typeName;
+                }
+            }
+        }
+        catch
+        {
+            // fall through
+        }
+
+        return null;
+    }
+
+    private static List<string> FindDeclaringTypesForMemberNameInAssembly(string assemblyPath, string memberName)
+    {
+        var result = new List<string>();
+
+        try
+        {
+            using var stream = File.OpenRead(assemblyPath);
+            using var peReader = new PEReader(stream);
+            if (!peReader.HasMetadata)
+            {
+                return result;
+            }
+
+            var md = peReader.GetMetadataReader();
+            foreach (var handle in md.TypeDefinitions)
+            {
+                var typeDef = md.GetTypeDefinition(handle);
+                if (HasMethod(typeDef, md, memberName)
+                    || HasProperty(typeDef, md, memberName)
+                    || HasField(typeDef, md, memberName)
+                    || HasEvent(typeDef, md, memberName))
+                {
+                    result.Add(GetTypeFullName(md, handle));
+                }
+            }
+        }
+        catch
+        {
+            // fall through
+        }
+
+        return result.Distinct(StringComparer.Ordinal).ToList();
+    }
 
     private static string GetTypeFullName(MetadataReader md, TypeDefinitionHandle handle)
     {

--- a/tests/Nupeek.Core.Tests/TypeDecompilePipelineTests.cs
+++ b/tests/Nupeek.Core.Tests/TypeDecompilePipelineTests.cs
@@ -14,6 +14,7 @@ public class TypeDecompilePipelineTests
             // Act
             var result = await pipeline.RunAsync(new TypeDecompileRequest(
                 "Humanizer.Core",
+                null,
                 "2.14.1",
                 "netstandard2.0",
                 "Humanizer.StringHumanizeExtensions",

--- a/web/downloads/nupeek-agent-skill.md
+++ b/web/downloads/nupeek-agent-skill.md
@@ -24,7 +24,9 @@ Skip this skill when:
 
 ## Workflow
 
-1. Resolve package name + version from project files/lock data.
+1. Resolve source input. Prefer **assembly mode** when possible (this is usually best in real projects):
+   - if the dependency DLL already exists in `bin/`, `obj/`, `.nuget/packages`, or project artifacts, use `--assembly`
+   - fall back to `--package` only when assembly path is unavailable
 
 2. If the user asks about a **method implementation**, inspect local code usage first:
    - find where the method is called in the current codebase
@@ -36,22 +38,30 @@ Skip this skill when:
 rg -n "WaitAndRetry\(" .
 ```
 
-3. Run Nupeek for the exact type first (narrow scope):
+3. Run Nupeek for the exact type first (narrow scope), preferring assembly input:
 
 ```bash
+# Preferred in ~99% of real tasks (assembly already present locally)
+nupeek type --assembly <path-to.dll> --type <Namespace.Type> --out deps-src
+
+# Fallback when assembly path is not available
 nupeek type --package <PackageId> --type <Namespace.Type> --out deps-src
 ```
 
 4. If the type is unknown, discover candidates from member/type symbol:
 
 ```bash
+# Preferred
+nupeek find --assembly <path-to.dll> --symbol <Namespace.TypeOrMember> --out deps-src
+
+# Fallback
 nupeek find --package <PackageId> --symbol <Namespace.TypeOrMember> --out deps-src
 ```
 
 5. If `find` returns multiple candidates for a member, choose one declaring type and rerun `type`:
 
 ```bash
-nupeek type --package <PackageId> --type <Resolved.Namespace.Type> --out deps-src
+nupeek type --assembly <path-to.dll> --type <Resolved.Namespace.Type> --out deps-src
 ```
 
 6. Choose output mode based on task:
@@ -85,6 +95,8 @@ When using Nupeek, report:
 
 ## CLI Options to Use Intentionally
 
+- `--assembly <path-to.dll>` → preferred source when dependency assembly already exists locally
+- `--package <id>` (+ optional `--version`) → fallback source when assembly path is unavailable
 - `--format text|json` → human vs machine-readable output
 - `--emit files|agent` → files-first vs inline agent payload
 - `--max-chars <n>` → inline source cap for `--emit agent`


### PR DESCRIPTION
## What changed
- Added `--assembly <path-to.dll>` source mode for both `nupeek type` and `nupeek find`.
- Source validation now requires exactly one input source:
  - `--package <id>` (existing)
  - `--assembly <dll>` (new)
- Added direct assembly resolution path in core pipeline:
  - bypasses NuGet acquisition
  - locates/decompiles type directly from provided DLL
  - supports member fallback inside the same assembly
- Updated CLI help/summary examples to include assembly usage.
- Updated skill files to recommend assembly-first workflow (preferred for most real projects where DLL already exists locally).

## Validation
- `dotnet test`
- manual smoke tests:
  - `nupeek type --assembly <Polly.Core.dll> --type "Polly.Retry.RetryStrategyOptions<T>" --out /tmp/nupeek-asm-test --format json --emit agent`
  - `nupeek find --assembly <Polly.Core.dll> --symbol MaxRetryAttempts --out /tmp/nupeek-asm-test3 --format json --emit agent`

Closes #97
