### PR TITLE
✨ feat(type): support --depth related-type decompilation

### DIFF
--- a/.github/skills/nupeek/SKILL.md
+++ b/.github/skills/nupeek/SKILL.md
@@ -44,6 +44,9 @@ rg -n "WaitAndRetry\(" .
 # Preferred in ~99% of real tasks (assembly already present locally)
 nupeek type --assembly <path-to.dll> --type <Namespace.Type> --out deps-src
 
+# Include directly related types (base + interfaces)
+nupeek type --assembly <path-to.dll> --type <Namespace.Type> --depth 1 --out deps-src
+
 # Fallback when assembly path is not available
 nupeek type --package <PackageId> --type <Namespace.Type> --out deps-src
 ```
@@ -100,6 +103,7 @@ When using Nupeek, report:
 - `--format text|json` → human vs machine-readable output
 - `--emit files|agent` → files-first vs inline agent payload
 - `--max-chars <n>` → inline source cap for `--emit agent`
+- `--depth <n>` → include related types (base/interfaces) when decompiling
 - `--progress auto|always|never` → terminal spinner behavior
 - `--dry-run` → show execution plan without decompiling
 

--- a/src/Nupeek.Cli/CliApp.cs
+++ b/src/Nupeek.Cli/CliApp.cs
@@ -91,7 +91,7 @@ public static class CliApp
 
         root.Description += Environment.NewLine + Environment.NewLine +
             "Command options:" + Environment.NewLine +
-            "  type: (--package|-p <id> | --assembly <dll>) --type --out [--version] [--tfm] [--format text|json] [--emit files|agent] [--max-chars N]" + Environment.NewLine +
+            "  type: (--package|-p <id> | --assembly <dll>) --type --out [--depth N] [--version] [--tfm] [--format text|json] [--emit files|agent] [--max-chars N]" + Environment.NewLine +
             "  find: (--package|-p <id> | --assembly <dll>) --symbol --out [--version] [--tfm] [--format text|json] [--emit files|agent] [--max-chars N]" + Environment.NewLine +
             "  list: (--package|-p <id> | --assembly <dll>) [--version] [--tfm] [--query text] [--format text|json]" + Environment.NewLine + Environment.NewLine +
             "Tip:" + Environment.NewLine +
@@ -154,6 +154,7 @@ public static class CliApp
         string type,
         string outDir,
         bool dryRun,
-        string? sourceSymbol = null)
-        => RunPlanTextBuilder.Build(command, package, version, tfm, type, outDir, dryRun, sourceSymbol);
+        string? sourceSymbol = null,
+        int depth = 0)
+        => RunPlanTextBuilder.Build(command, package, version, tfm, type, outDir, dryRun, sourceSymbol, depth);
 }

--- a/src/Nupeek.Cli/Contracts/PlanRequest.cs
+++ b/src/Nupeek.Cli/Contracts/PlanRequest.cs
@@ -7,6 +7,7 @@ internal sealed record PlanRequest(
     string Version,
     string Tfm,
     string Type,
+    int Depth,
     string OutDir,
     bool Verbose,
     bool Quiet,

--- a/src/Nupeek.Cli/Features/Find/FindCommandFactory.cs
+++ b/src/Nupeek.Cli/Features/Find/FindCommandFactory.cs
@@ -53,6 +53,7 @@ internal static class FindCommandFactory
                 Version: parse.GetValueForOption(versionOption) ?? "latest",
                 Tfm: parse.GetValueForOption(tfmOption) ?? "auto",
                 Type: SymbolParser.ToTypeName(symbol),
+                Depth: 0,
                 OutDir: parse.GetValueForOption(outOption)!,
                 Verbose: parse.GetValueForOption(globalOptions.Verbose),
                 Quiet: parse.GetValueForOption(globalOptions.Quiet),

--- a/src/Nupeek.Cli/Features/RunPlan/RunPlanOutcomeEmitter.cs
+++ b/src/Nupeek.Cli/Features/RunPlan/RunPlanOutcomeEmitter.cs
@@ -71,7 +71,8 @@ RunPlanSourceLabel.Get(request),
             request.Type,
             request.OutDir,
             request.DryRun,
-            request.SourceSymbol));
+            request.SourceSymbol,
+            request.Depth));
     }
 
     private static void EmitGeneratedPaths(CliOutcome outcome)

--- a/src/Nupeek.Cli/Features/RunPlan/RunPlanRealExecution.cs
+++ b/src/Nupeek.Cli/Features/RunPlan/RunPlanRealExecution.cs
@@ -17,6 +17,7 @@ internal static class RunPlanRealExecution
                 string.Equals(request.Version, "latest", StringComparison.OrdinalIgnoreCase) ? null : request.Version,
                 string.Equals(request.Tfm, "auto", StringComparison.OrdinalIgnoreCase) ? null : request.Tfm,
                 normalizedType,
+                request.Depth,
                 request.OutDir), cancellationToken).ConfigureAwait(false);
 
             var inlineSource = await InlineSourceReader

--- a/src/Nupeek.Cli/Features/RunPlan/RunPlanTextBuilder.cs
+++ b/src/Nupeek.Cli/Features/RunPlan/RunPlanTextBuilder.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Text;
 
 namespace Nupeek.Cli;
@@ -12,7 +13,8 @@ internal static class RunPlanTextBuilder
         string type,
         string outDir,
         bool dryRun,
-        string? sourceSymbol = null)
+        string? sourceSymbol = null,
+        int depth = 0)
     {
         var sb = new StringBuilder();
         sb.AppendLine("Nupeek execution plan");
@@ -27,6 +29,7 @@ internal static class RunPlanTextBuilder
         }
 
         sb.AppendLine($"type: {type}");
+        sb.AppendLine($"depth: {depth.ToString(CultureInfo.InvariantCulture)}");
         sb.AppendLine($"out: {outDir}");
         sb.AppendLine($"dryRun: {dryRun}");
 

--- a/src/Nupeek.Cli/Features/Type/TypeCommandFactory.cs
+++ b/src/Nupeek.Cli/Features/Type/TypeCommandFactory.cs
@@ -15,6 +15,7 @@ internal static class TypeCommandFactory
         var tfmOption = new Option<string?>("--tfm", "Target framework moniker. Defaults to auto.");
         var typeOption = new Option<string>("--type", "Fully-qualified type name (e.g. Namespace.Type)") { IsRequired = true };
         var outOption = new Option<string>("--out", "Output directory (e.g. deps-src)") { IsRequired = true };
+        var depthOption = new Option<int>("--depth", () => 0, "Related-type expansion depth. 0 = only requested type.");
         var formatOption = new Option<string>("--format", () => "text", "Output format: text (default) or json.");
         var emitOption = new Option<string>("--emit", () => "files", "Emit mode: files (default) or agent.");
         var maxCharsOption = new Option<int>("--max-chars", () => 12000, "Max inline source chars for --emit agent.");
@@ -26,6 +27,7 @@ internal static class TypeCommandFactory
         command.AddOption(tfmOption);
         command.AddOption(typeOption);
         command.AddOption(outOption);
+        command.AddOption(depthOption);
         command.AddOption(formatOption);
         command.AddOption(emitOption);
         command.AddOption(maxCharsOption);
@@ -51,6 +53,7 @@ internal static class TypeCommandFactory
                 Version: parse.GetValueForOption(versionOption) ?? "latest",
                 Tfm: parse.GetValueForOption(tfmOption) ?? "auto",
                 Type: parse.GetValueForOption(typeOption)!,
+                Depth: Math.Max(0, parse.GetValueForOption(depthOption)),
                 OutDir: parse.GetValueForOption(outOption)!,
                 Verbose: parse.GetValueForOption(globalOptions.Verbose),
                 Quiet: parse.GetValueForOption(globalOptions.Quiet),

--- a/src/Nupeek.Core/Features/DecompileType/Contracts/TypeDecompileRequest.cs
+++ b/src/Nupeek.Core/Features/DecompileType/Contracts/TypeDecompileRequest.cs
@@ -8,6 +8,7 @@ namespace Nupeek.Core;
 /// <param name="Version">Optional package version. If null, latest stable is used.</param>
 /// <param name="Tfm">Optional target framework. If null, best available is selected.</param>
 /// <param name="TypeName">Fully-qualified target type name to decompile.</param>
+/// <param name="Depth">Related-type traversal depth. 0 = only target type.</param>
 /// <param name="OutputRoot">Output root for generated source and catalogs.</param>
 public sealed record TypeDecompileRequest(
     string? PackageId,
@@ -15,4 +16,5 @@ public sealed record TypeDecompileRequest(
     string? Version,
     string? Tfm,
     string TypeName,
+    int Depth,
     string OutputRoot);

--- a/src/Nupeek.Core/Features/DecompileType/TypeDecompilePipeline.cs
+++ b/src/Nupeek.Core/Features/DecompileType/TypeDecompilePipeline.cs
@@ -47,24 +47,36 @@ public sealed class TypeDecompilePipeline
         var source = await ResolveSourceAsync(request, cancellationToken).ConfigureAwait(false);
         var content = source.Content;
 
-        var outputPath = OutputPathBuilder.BuildTypeOutputPath(
+        var outputPath = await DecompileAndCatalogAsync(
             request.OutputRoot,
             source.PackageId,
             source.Version,
             content.SelectedTfm,
-            content.FullTypeName);
-
-        await _decompiler.DecompileTypeAsync(content.AssemblyPath, content.FullTypeName, outputPath, cancellationToken).ConfigureAwait(false);
-
-        var indexPath = await _catalogWriter.WriteIndexAsync(request.OutputRoot, content.FullTypeName, outputPath, cancellationToken).ConfigureAwait(false);
-        var manifestPath = await _catalogWriter.WriteManifestAsync(request.OutputRoot, new ManifestEntry(
-            source.PackageId,
-            source.Version,
-            content.SelectedTfm,
-            content.FullTypeName,
             content.AssemblyPath,
-            outputPath,
-            DateTimeOffset.UtcNow), cancellationToken).ConfigureAwait(false);
+            content.FullTypeName,
+            cancellationToken).ConfigureAwait(false);
+
+        if (request.Depth > 0)
+        {
+            var related = await _locator
+                .GetRelatedTypesInAssemblyAsync(content.AssemblyPath, content.FullTypeName, request.Depth, cancellationToken)
+                .ConfigureAwait(false);
+
+            foreach (var relatedType in related)
+            {
+                await DecompileAndCatalogAsync(
+                    request.OutputRoot,
+                    source.PackageId,
+                    source.Version,
+                    content.SelectedTfm,
+                    content.AssemblyPath,
+                    relatedType,
+                    cancellationToken).ConfigureAwait(false);
+            }
+        }
+
+        var indexPath = Path.Combine(request.OutputRoot, "index.json");
+        var manifestPath = Path.Combine(request.OutputRoot, "manifest.json");
 
         return new TypeDecompileResult(
             source.PackageId,
@@ -104,5 +116,29 @@ public sealed class TypeDecompilePipeline
         var packageContent = await _locator.LocateAsync(new PackageContentRequest(package.ExtractedPath, request.TypeName, request.Tfm), cancellationToken).ConfigureAwait(false);
 
         return (package.PackageId, package.Version, packageContent);
+    }
+
+    private async Task<string> DecompileAndCatalogAsync(
+        string outputRoot,
+        string packageId,
+        string version,
+        string tfm,
+        string assemblyPath,
+        string fullTypeName,
+        CancellationToken cancellationToken)
+    {
+        var outputPath = OutputPathBuilder.BuildTypeOutputPath(outputRoot, packageId, version, tfm, fullTypeName);
+        await _decompiler.DecompileTypeAsync(assemblyPath, fullTypeName, outputPath, cancellationToken).ConfigureAwait(false);
+        await _catalogWriter.WriteIndexAsync(outputRoot, fullTypeName, outputPath, cancellationToken).ConfigureAwait(false);
+        await _catalogWriter.WriteManifestAsync(outputRoot, new ManifestEntry(
+            packageId,
+            version,
+            tfm,
+            fullTypeName,
+            assemblyPath,
+            outputPath,
+            DateTimeOffset.UtcNow), cancellationToken).ConfigureAwait(false);
+
+        return outputPath;
     }
 }

--- a/src/Nupeek.Core/Features/LocateType/PackageTypeLocator.cs
+++ b/src/Nupeek.Core/Features/LocateType/PackageTypeLocator.cs
@@ -333,29 +333,18 @@ public sealed class PackageTypeLocator
                     cancellationToken.ThrowIfCancellationRequested();
                     var typeDef = md.GetTypeDefinition(handle);
                     var fullTypeName = GetTypeFullName(md, handle);
-                    var members = new HashSet<string>(StringComparer.Ordinal);
+                    var members = CollectMemberNames(md, typeDef);
 
-                    foreach (var method in typeDef.GetMethods().Select(md.GetMethodDefinition))
-                    {
-                        members.Add(md.GetString(method.Name));
-                    }
+                    var baseType = ResolveEntityTypeName(md, typeDef.BaseType);
+                    var interfaces = typeDef.GetInterfaceImplementations()
+                        .Select(md.GetInterfaceImplementation)
+                        .Select(x => ResolveEntityTypeName(md, x.Interface))
+                        .Where(static x => !string.IsNullOrWhiteSpace(x))
+                        .Cast<string>()
+                        .Distinct(StringComparer.Ordinal)
+                        .ToList();
 
-                    foreach (var property in typeDef.GetProperties().Select(md.GetPropertyDefinition))
-                    {
-                        members.Add(md.GetString(property.Name));
-                    }
-
-                    foreach (var field in typeDef.GetFields().Select(md.GetFieldDefinition))
-                    {
-                        members.Add(md.GetString(field.Name));
-                    }
-
-                    foreach (var eventDef in typeDef.GetEvents().Select(md.GetEventDefinition))
-                    {
-                        members.Add(md.GetString(eventDef.Name));
-                    }
-
-                    result.Add(new TypeMetadata(fullTypeName, members));
+                    result.Add(new TypeMetadata(fullTypeName, members, baseType, interfaces));
                 }
             }
             catch
@@ -385,6 +374,92 @@ public sealed class PackageTypeLocator
         return (await Task.WhenAll(tasks).ConfigureAwait(false)).ToList();
     }
 
+    public async Task<IReadOnlyList<string>> GetRelatedTypesInAssemblyAsync(
+        string assemblyPath,
+        string rootTypeName,
+        int depth,
+        CancellationToken cancellationToken = default)
+    {
+        if (depth <= 0)
+        {
+            return [];
+        }
+
+        var normalizedRoot = TypeNameNormalizer.Normalize(rootTypeName);
+        var types = await ReadTypeMetadataAsync(assemblyPath, cancellationToken).ConfigureAwait(false);
+        var map = types
+            .GroupBy(static x => x.FullTypeName, StringComparer.Ordinal)
+            .ToDictionary(static g => g.Key, static g => g.First(), StringComparer.Ordinal);
+
+        var visited = new HashSet<string>(StringComparer.Ordinal) { normalizedRoot };
+        var frontier = new HashSet<string>(StringComparer.Ordinal) { normalizedRoot };
+
+        for (var level = 0; level < depth; level++)
+        {
+            var next = new HashSet<string>(StringComparer.Ordinal);
+
+            foreach (var current in frontier)
+            {
+                if (!map.TryGetValue(current, out var meta))
+                {
+                    continue;
+                }
+
+                if (!string.IsNullOrWhiteSpace(meta.BaseType)
+                    && !string.Equals(meta.BaseType, "System.Object", StringComparison.Ordinal)
+                    && map.ContainsKey(meta.BaseType)
+                    && visited.Add(meta.BaseType))
+                {
+                    next.Add(meta.BaseType);
+                }
+
+                foreach (var iface in meta.Interfaces)
+                {
+                    if (map.ContainsKey(iface) && visited.Add(iface))
+                    {
+                        next.Add(iface);
+                    }
+                }
+            }
+
+            frontier = next;
+            if (frontier.Count == 0)
+            {
+                break;
+            }
+        }
+
+        visited.Remove(normalizedRoot);
+        return visited.OrderBy(static x => x, StringComparer.Ordinal).ToList();
+    }
+
+    private static HashSet<string> CollectMemberNames(MetadataReader md, TypeDefinition typeDef)
+    {
+        var members = new HashSet<string>(StringComparer.Ordinal);
+
+        foreach (var method in typeDef.GetMethods().Select(md.GetMethodDefinition))
+        {
+            members.Add(md.GetString(method.Name));
+        }
+
+        foreach (var property in typeDef.GetProperties().Select(md.GetPropertyDefinition))
+        {
+            members.Add(md.GetString(property.Name));
+        }
+
+        foreach (var field in typeDef.GetFields().Select(md.GetFieldDefinition))
+        {
+            members.Add(md.GetString(field.Name));
+        }
+
+        foreach (var eventDef in typeDef.GetEvents().Select(md.GetEventDefinition))
+        {
+            members.Add(md.GetString(eventDef.Name));
+        }
+
+        return members;
+    }
+
     private static string GetTypeFullName(MetadataReader md, TypeDefinitionHandle handle)
     {
         var typeDef = md.GetTypeDefinition(handle);
@@ -393,5 +468,29 @@ public sealed class PackageTypeLocator
         return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
     }
 
-    private sealed record TypeMetadata(string FullTypeName, HashSet<string> MemberNames);
+    private static string? ResolveEntityTypeName(MetadataReader md, EntityHandle handle)
+    {
+        if (handle.IsNil)
+        {
+            return null;
+        }
+
+        return handle.Kind switch
+        {
+            HandleKind.TypeDefinition => GetTypeFullName(md, (TypeDefinitionHandle)handle),
+            HandleKind.TypeReference => GetTypeFullName(md, (TypeReferenceHandle)handle),
+            HandleKind.TypeSpecification => null,
+            _ => null,
+        };
+    }
+
+    private static string GetTypeFullName(MetadataReader md, TypeReferenceHandle handle)
+    {
+        var typeRef = md.GetTypeReference(handle);
+        var ns = md.GetString(typeRef.Namespace);
+        var name = md.GetString(typeRef.Name);
+        return string.IsNullOrEmpty(ns) ? name : $"{ns}.{name}";
+    }
+
+    private sealed record TypeMetadata(string FullTypeName, HashSet<string> MemberNames, string? BaseType, IReadOnlyList<string> Interfaces);
 }

--- a/tests/Nupeek.Core.Tests/TypeDecompilePipelineTests.cs
+++ b/tests/Nupeek.Core.Tests/TypeDecompilePipelineTests.cs
@@ -18,6 +18,7 @@ public class TypeDecompilePipelineTests
                 "2.14.1",
                 "netstandard2.0",
                 "Humanizer.StringHumanizeExtensions",
+                0,
                 outputRoot));
 
             // Assert

--- a/web/downloads/nupeek-agent-skill.md
+++ b/web/downloads/nupeek-agent-skill.md
@@ -44,6 +44,9 @@ rg -n "WaitAndRetry\(" .
 # Preferred in ~99% of real tasks (assembly already present locally)
 nupeek type --assembly <path-to.dll> --type <Namespace.Type> --out deps-src
 
+# Include directly related types (base + interfaces)
+nupeek type --assembly <path-to.dll> --type <Namespace.Type> --depth 1 --out deps-src
+
 # Fallback when assembly path is not available
 nupeek type --package <PackageId> --type <Namespace.Type> --out deps-src
 ```
@@ -100,6 +103,7 @@ When using Nupeek, report:
 - `--format text|json` → human vs machine-readable output
 - `--emit files|agent` → files-first vs inline agent payload
 - `--max-chars <n>` → inline source cap for `--emit agent`
+- `--depth <n>` → include related types (base/interfaces) when decompiling
 - `--progress auto|always|never` → terminal spinner behavior
 - `--dry-run` → show execution plan without decompiling
 


### PR DESCRIPTION
## What changed
- Added `--depth <n>` to `nupeek type` (default 0).
- Extended core request pipeline with depth support.
- Implemented related-type expansion for depth >=1:
  - base type (when resolvable in same assembly)
  - implemented interfaces (when resolvable in same assembly)
- Pipeline now decompiles and catalogs related types in the same run.
- Updated execution plan text to include depth.
- Updated Nupeek skill files (repo + downloadable) with new depth usage guidance.

## Validation
- `dotnet test`
- Smoke test:
  - `nupeek type --assembly <Polly.Core.dll> --type 'Polly.Retry.RetryStrategyOptions<T>' --depth 1 --out /tmp/nupeek-depth-test2`
  - produced multiple manifest entries (target + related)

Closes #102
