### PR TITLE
📝 docs: improve graph usage/help and output file guidance

### DIFF
--- a/.github/skills/nupeek/SKILL.md
+++ b/.github/skills/nupeek/SKILL.md
@@ -82,6 +82,28 @@ nupeek type --package <PackageId> --type <Namespace.Type> --out deps-src
 - Decompiled source file(s)
 - `index.json` for quick navigation
 - `manifest.json` for run metadata
+- Graph exports from `nupeek graph`:
+  - `graph.types.json` → type nodes (name/full name/base/interfaces)
+  - `graph.members.json` → methods/properties/fields/events per type
+  - `graph.edges.json` → structural relations (`inherits`, `implements`)
+  - `graph.globals.json` → static fields/constants (global-like state)
+
+Example graph command and output shape:
+
+```bash
+nupeek graph --assembly <path-to.dll> --type <Namespace.Type> --depth 2 --out deps-src
+```
+
+```json
+// graph.types.json
+[{ "Name": "RetryStrategyOptions`1", "FullName": "Polly.Retry.RetryStrategyOptions`1", "BaseType": "Polly.ResilienceStrategyOptions", "Interfaces": [] }]
+
+// graph.members.json
+[{ "DeclaringType": "Polly.Retry.RetryStrategyOptions`1", "Kind": "property", "Name": "MaxRetryAttempts", "IsStatic": false, "Visibility": "unknown" }]
+
+// graph.edges.json
+[{ "FromType": "Polly.Retry.RetryStrategyOptions`1", "Relation": "inherits", "ToType": "Polly.ResilienceStrategyOptions" }]
+```
 
 8. Base guidance/patches on observed implementation, not API guesswork.
 

--- a/docs/README_DEEP.md
+++ b/docs/README_DEEP.md
@@ -13,6 +13,7 @@ Without source visibility, agents often infer behavior from signatures/docs only
 ```bash
 nupeek type --package <id> [--version <v>] [--tfm <tfm>] --type "<Namespace.Type>" --out deps-src [--depth <n>] [--progress auto|always|never]
 nupeek find --package <id> [--version <v>] [--tfm <tfm>] --symbol "<Namespace.Type.Method>" --out deps-src [--progress auto|always|never]
+nupeek graph --assembly <path-to.dll> [--type "<Namespace.Type>"] [--depth <n>] --out deps-src
 ```
 
 ## Typical output layout
@@ -45,11 +46,30 @@ nupeek find --package Polly \
   --out deps-src --dry-run false
 ```
 
+## Graph output files (for agents)
+
+`nupeek graph` writes four machine-readable files to your `--out` directory:
+
+- `graph.types.json` → type nodes (`Name`, `FullName`, `BaseType`, `Interfaces`)
+- `graph.members.json` → member nodes (`DeclaringType`, `Kind`, `Name`, `IsStatic`, `Visibility`)
+- `graph.edges.json` → type relations (`inherits`, `implements`)
+- `graph.globals.json` → static/global-like fields and constants
+
+Minimal real-world shape:
+
+```json
+// graph.types.json
+[{ "Name": "ResilienceStrategyOptions", "FullName": "Polly.ResilienceStrategyOptions", "BaseType": "System.Object", "Interfaces": [] }]
+
+// graph.edges.json
+[{ "FromType": "Polly.Retry.RetryStrategyOptions`1", "Relation": "inherits", "ToType": "Polly.ResilienceStrategyOptions" }]
+```
+
 ## Notes
 
 - Generated sources are local artifacts; avoid redistributing decompiled output.
 - Nupeek is optimized for targeted inspection, not whole ecosystem dumps.
-- Use `index.json` and `manifest.json` for deterministic lookup/provenance.
+- Use `index.json`, `manifest.json`, and graph JSON files for deterministic lookup/provenance.
 
 ## Related docs
 

--- a/src/Nupeek.Cli/CliApp.cs
+++ b/src/Nupeek.Cli/CliApp.cs
@@ -105,7 +105,8 @@ public static class CliApp
             "  nupeek find --package Dapper --symbol Dapper.SqlMapper.Query --out deps-src --progress never" + Environment.NewLine +
             "  nupeek type --assembly ./bin/Debug/net8.0/MyApp.Services.dll --type MyApp.Services.RetryHelper --out deps-src" + Environment.NewLine +
             "  nupeek list --assembly ./bin/Debug/net8.0/MyApp.Services.dll --query Retry" + Environment.NewLine +
-            "  nupeek graph --assembly ./bin/Debug/net8.0/MyApp.Services.dll --type MyApp.Services.RetryHelper --depth 2 --out deps-src";
+            "  nupeek graph --assembly ./bin/Debug/net8.0/MyApp.Services.dll --type MyApp.Services.RetryHelper --depth 2 --out deps-src" + Environment.NewLine +
+            "  # Graph files: graph.types.json, graph.members.json, graph.edges.json, graph.globals.json";
 
         root.AddCommand(TypeCommandFactory.Create(globalOptions, request => RunPlanHandler.RunAsync(request, cancellationToken)));
         root.AddCommand(FindCommandFactory.Create(globalOptions, request => RunPlanHandler.RunAsync(request, cancellationToken)));

--- a/web/downloads/nupeek-agent-skill.md
+++ b/web/downloads/nupeek-agent-skill.md
@@ -82,6 +82,28 @@ nupeek type --package <PackageId> --type <Namespace.Type> --out deps-src
 - Decompiled source file(s)
 - `index.json` for quick navigation
 - `manifest.json` for run metadata
+- Graph exports from `nupeek graph`:
+  - `graph.types.json` → type nodes (name/full name/base/interfaces)
+  - `graph.members.json` → methods/properties/fields/events per type
+  - `graph.edges.json` → structural relations (`inherits`, `implements`)
+  - `graph.globals.json` → static fields/constants (global-like state)
+
+Example graph command and output shape:
+
+```bash
+nupeek graph --assembly <path-to.dll> --type <Namespace.Type> --depth 2 --out deps-src
+```
+
+```json
+// graph.types.json
+[{ "Name": "RetryStrategyOptions`1", "FullName": "Polly.Retry.RetryStrategyOptions`1", "BaseType": "Polly.ResilienceStrategyOptions", "Interfaces": [] }]
+
+// graph.members.json
+[{ "DeclaringType": "Polly.Retry.RetryStrategyOptions`1", "Kind": "property", "Name": "MaxRetryAttempts", "IsStatic": false, "Visibility": "unknown" }]
+
+// graph.edges.json
+[{ "FromType": "Polly.Retry.RetryStrategyOptions`1", "Relation": "inherits", "ToType": "Polly.ResilienceStrategyOptions" }]
+```
 
 8. Base guidance/patches on observed implementation, not API guesswork.
 


### PR DESCRIPTION
## What changed
- Improved root CLI help examples for `nupeek graph` and made graph artifacts visible in help text.
- Expanded skill docs with a dedicated graph output explanation:
  - what each file contains (`graph.types.json`, `graph.members.json`, `graph.edges.json`, `graph.globals.json`)
  - concrete JSON snippets showing real shapes
- Updated `docs/README_DEEP.md` with graph command and output file section.
- Synced downloadable skill mirror.

## Validation
- `dotnet test`

Closes #108
